### PR TITLE
Fixed each example's result

### DIFF
--- a/02-intermediate-ruby/07-enumerable.md
+++ b/02-intermediate-ruby/07-enumerable.md
@@ -56,7 +56,7 @@ These do the same thing. The iterate the collection and return an array of the _
 # using `each`
 results = []
 [1,2,3].each { |n| results << n ** 2 }
-results # => [1, 4, 9]
+results # => [1, 2, 3]
 
 # using `map` or `collect`
 results = [1,2,3].map { |n| n ** 2 }


### PR DESCRIPTION
Going over Enumerables just now, I noticed that the [1 ,2 ,3].each loop iterating to do n ** 2 was showing [1, 4, 9] as the results in the markdown file. I remembered Kari saying in class each won't accomplish this and map/collect is necessary. (Verified in IRB that the code results in [1, 2, 3] before making pull request; wanted to save someone some time by making the pull request myself.)