### PR TITLE
Reformat Intro to CSS

### DIFF
--- a/05-html-css/04-css-intro.md
+++ b/05-html-css/04-css-intro.md
@@ -16,37 +16,38 @@ covering all of them
 - __Selector__ is the thing you want to style
 - __Property__ is what aspect you want to style
 - __Value__ is how you want to style it
-- __Property__ + value = declaration
-- __Declarations__ end in semicolons (;)
+- Property + value = __declaration__
+- Declarations end in semicolons (;)
 - Selector + declaration = __rule__
 
 ## Selectors
 
 CSS selectors are used to "find" (or select) HTML elements. There are a few different ways that we can select elements using CSS:
-1) __Elements__: `h1 { property: value; }`
-2) __Classes__: classes are used in html to group elements. These are particularly helpful when you want to select only a subset of an element type (only first paragraphs, etc).
-In your html, classes appear like:
-`<p class="intro">words</p>`
-In CSS, you would select a class like:
-`.intro {background-color: yellow;}`
-3) __IDs__: IDs are used in html to identify a single instance of an element. There can only be one of a particular ID. Since these are so specific, they can't be reused, and can cause extra clutter in your stylesheet. Try to avoid these in general, but they are sometimes an appropriate choice.
-In your html, IDs appear like: `<p id="second-p">more words</p>`.
-In CSS, you would select an ID like: `#second-p {background-color: blue;}
-4) __Pseudoclasses__: A pseudoclass is used to define styles on a special state of an element. You can select these on an element without designating it in the HTML. The most common of these are hover, visited, and focus.
-`p:hover {color: red;}`
-`p:visited {color: purple;}`
-`p:focus {border-color: pink;}`
 
-##The Cascade and Precedence
+1. __Elements__: `h1 { property: value; }`
+1. __Classes__: classes are used in html to group elements. These are particularly helpful when you want to select only a subset of an element type (only first paragraphs, etc).
+    * In HTML, add a class to an element: `<p class="intro">words</p>`
+    * In CSS, select elements with a given class: `.intro {background-color: yellow;}`
+1. __IDs__: IDs are used in html to identify a specific element. IDs are *globally unique*, meaning each ID can be used only once in an HTML document. Because IDs can't be reused, they often lead to extra clutter in your style sheet, and should be used sparingly.
+    * In HTML, add an ID to an element: `<p id="second-p">more words</p>`.
+    * In CSS, select the element with a given ID: `#second-p {background-color: blue;}`
+1. __Pseudoclasses__: A pseudoclass is used to define styles on a special state of an element. You can select these on an element without designating it in the HTML. The most common of these are hover, visited, and focus.
+```css
+p:hover {color: red;}
+p:visited {color: purple;}
+p:focus {border-color: pink;}
+```
+
+## The Cascade and Precedence
 Within CSS, all styles __cascade__ from the top of a style sheet to the bottom, allowing different styles to be added or overwritten as the style sheet progresses. The cascade also works with properties inside individual selectors. Two examples:
-```html
+```css
   .intro {
     background-color: yellow;
     background-color: brown;
   }
 ```
 
-```html
+```css
   .intro {
     background-color: yellow;
   }
@@ -58,8 +59,7 @@ Within CSS, all styles __cascade__ from the top of a style sheet to the bottom, 
 In both cases `background-color: brown;` overwrites `background-color: yellow;`
 
 Specificity: The __specificity__ of your selector can clash with the cascade.
-```html
-  ```html
+```css
   .intro {
     background-color: brown;
   }
@@ -70,7 +70,7 @@ Specificity: The __specificity__ of your selector can clash with the cascade.
 ```
 In this case, the `.intro` style will _not_ be overridden by the `p` style, even though the `p` comes after `.intro`. This is because a class is more specific than an element. Element < Class < ID.
 
-##Combining Selectors:
+## Combining Selectors:
 You are not limited to a single selector at a time. You have a number of options that allow you be a little more specific.
 - `.class p` - This selects any paragraphs that are _children_ of the class. Notice that there is a space between `.class` and `p`. This is important because this is what defines that we're selecting only `p` elements that are children of `.class`.
 - `p.class` - This selects any `p` that _also_ has that class assigned to it.
@@ -78,19 +78,19 @@ You are not limited to a single selector at a time. You have a number of options
 We are using a class and an element in this example, but you can use combinations of elements, classes, or IDs.
 Combining selectors can be very useful, but you should be careful not to go overboard. The selectors we combine, the more specific we get; The more specific we get, the more likely you are to run into trouble.
 
-##Grouping Selectors:
+## Grouping Selectors:
 If you have some styles that apply to multiple selectors, you can consolidate these. Instead of using a separate rule for each selector, you can group these selectors. This eliminates redundancy.
-```html
+```css
 p {background-color: yellow;}
 li {background-color: yellow;}
 footer {background-color: yellow;}
 ```
 Group selectors like so:
-```html
+```css
 p, li, footer {background-color: yellow;}
 ```
 
-##Units
+## Units
 Many properties require some measure of size (font-size, width, etc). There are a number of common units:
 - __px__ - Pixels are an absolute unit, meaning their size does not change with screen size. This is very common, but has some shortcomings. For instance, if you use pixels, and your user zooms in, your layout is likely to break.
 - __em__ - This is a relative unit. Not to be confused with the `<em>` tag. Em is a proportion of the parent's value. This requires more math and can be more difficult to implement than...
@@ -128,6 +128,3 @@ usually in ems (em) or pixels (px)
   - Also possible but not preferred: red
 
 A large list of [common CSS properties here](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Properties_Reference)
-
-
-


### PR DESCRIPTION
Some of the formatting wasn't rendering properly, particularly around
the section on selectors. This is now fixed.

Re-labeled code segments from HTML to CSS so they will be correctly
syntax-highlighted.

Re-worded a couple things to increase clarity.

Re-formatted version can be found at https://github.com/droberts-ada/textbook-curriculum/blob/topics/CSS_selector_formatting/05-html-css/04-css-intro.md