### PR TITLE
Collections: fix first code sample for createTask

### DIFF
--- a/11-Backbonejs/05-Backbone-Collections.md
+++ b/11-Backbonejs/05-Backbone-Collections.md
@@ -115,22 +115,22 @@ Finally, since `addTask()` has changed, in `createTask()` we need to turn the ra
 ```javascript
 // Get the input data from the form and turn it into a task
 var TaskListView = Backbone.View.extend({
-	// ...
-  render: function() {
-		// ...
+  // ...
+  createTask: function(event) {
+    // ...
 
-		// Get the input data from the form and turn it into a task
+    // Get the input data from the form and turn it into a task
     var task = new Task(this.getInput());
 
     // Create a card for the task
     this.addTask(task);
 
-		// Add the task to our Collection
-		this.model.add(task);
+    // Add the task to our Collection
+    this.model.add(task);
 
-		// ...
-	},
-	// ...
+    // ...
+  },
+  // ...
 });
 ```
 


### PR DESCRIPTION
In the Backbone Collections lecture, in the first part (retrofitting our
app to use collections), the code sample for createTask() was wrong. It
said we were changing render(), and used tabs instead of spaces. Not
quite sure how this happened, but it's fixed now.