### PR TITLE
Fix Markdown headers

### DIFF
--- a/00-programming-fundamentals/xx-debug.md
+++ b/00-programming-fundamentals/xx-debug.md
@@ -1,4 +1,4 @@
-#Bug Off!
+# Bug Off!
 ## Debugging with Pry
 
 

--- a/01-ruby-fundamentals/03-iteration-and-blocks.md
+++ b/01-ruby-fundamentals/03-iteration-and-blocks.md
@@ -1,5 +1,5 @@
 # Iteration & Blocks
-##Learning Goals
+## Learning Goals
 - Learn what _Iteration_ is and how to do it.
 - Learn what _Blocks_ are and how to recognize them.
 - Use a _Loop Table_ to clarify how values change over the course of an iteration.

--- a/01-ruby-fundamentals/03a-loop-table-worksheet.md
+++ b/01-ruby-fundamentals/03a-loop-table-worksheet.md
@@ -1,4 +1,4 @@
-#Loop Table Worksheet!
+# Loop Table Worksheet!
 
 
 1) Complete the following loop table by filling in the values for **loop count**, **value of x**, and **output**.

--- a/03-leadership-and-inclusion/06b-Advocacy-Discussion.md
+++ b/03-leadership-and-inclusion/06b-Advocacy-Discussion.md
@@ -1,6 +1,6 @@
 # Advocating for an Equitable Culture
 
-#Learning Goals
+# Learning Goals
 + To share strategies for dealing with difficult situations.
 
 ## Activity

--- a/03-leadership-and-inclusion/Creating Inclusive Community (Sarah).md
+++ b/03-leadership-and-inclusion/Creating Inclusive Community (Sarah).md
@@ -1,20 +1,20 @@
-#Creating Inclusive Community
-##2.5 hour workshop
+# Creating Inclusive Community
+## 2.5 hour workshop
 
-##Objective:
+## Objective:
 Create a supportive forum in which students can define what inclusive community means at Ada and give direct feedback to each other and to staff about how to improve inclusivity in our community. Students will use skills from the Implicit Bias workshop by thinking about how aspects of Ada's culture may feel to students of culturally marginalized identities and by approaching inclusivity with an intersectional lens. 
 
-##Community Affirmation Activity (30 min)
+## Community Affirmation Activity (30 min)
 
 Have all participants sit and close their eyes. Dim the lights and start with a short breathing exercise. Have about 1/5 of the group open their eyes and stand. Give an  instruction to those standing like, "Touch the should of several people who made you feel really welcome the first week." They will slowly circulate and touch the shoulders of classmates gently. Give several more affirmations and then have those students sit and others stand. Do this until all students have had the opportunity to stand.
 *As facilitator, be aware of group dynamics. At times, ask participants to touch the shoulders of only people they haven't affirmed yet. Step in and give your own shoulder touches when appropriate.*
 
-##Building Our Container (20 min)
+## Building Our Container (20 min)
 
 Draw a large jar or box on the whiteboard to write over. Ask the group, "What makes you feel safe during uncomfortable or difficult conversations?" "What will hold us together as a community during this workshop, rather than break us down?"
 *This is an alternative to writing "ground rules." This will sometimes branch into a larger conversation about how we want to handle ignorant or potentially hurtful statements. Let it happen.*
 
-##Break Out Discussion (45 min)
+## Break Out Discussion (45 min)
 
 During the container, distribute a bowl for students to randomly draw numbers for the small group discussion. Based on the number they drew, they will meet their randomly assigned group in a particular location of the building where they'll find a packet to guide the conversation. Before sending them off to their groups, let them know that the goal of the conversation is to define what inclusive community means to us and how we can move closer to that Ada, both institutionally and socially. Ask them to be aware of speaking time and creating space for quieter group members. Take questions.
 
@@ -31,10 +31,10 @@ Packet Questions:
   6. What would you like to see Ada students do to increase inclusivity?
   *Think about whether you're comfortable sharing this in the large group.*
 
-##Large Group discussion (30 min)
+## Large Group discussion (30 min)
 
 Go through the questions and ask for groups to share what they discussed. Each one should produce some responses and conversation. As time winds down, let them know your plan for follow-up. (Take feedback to other staff anonymously, outcomes report at next workshop.) Let them know you will be send out [This Google Doc](https://docs.google.com/a/adadevelopersacademy.org/forms/d/1EuzUZ3MhtxR-pmM3Au418PBjGltDex7U4yT3Hgveyqk/edit) as an opportunity for everyone to reflect individually on the success of their small group in representing everyone's ideas, and on inclusivity within their respective class.
 
-##Return to the Container (5-10 min)
+## Return to the Container (5-10 min)
 
 How did we do in conversation respecting the container? Anything we would add or change with hindsight? Final thoughts.

--- a/03-leadership-and-inclusion/Implicit Bias (Sarah).md
+++ b/03-leadership-and-inclusion/Implicit Bias (Sarah).md
@@ -1,7 +1,7 @@
-#Confronting Implicit Bias and Microaggression
-##2.5 hour workshop
+# Confronting Implicit Bias and Microaggression
+## 2.5 hour workshop
 
-##Objectives:
+## Objectives:
 
 Using an intersectional lens, students will develop an understanding of what implicit bias is, how it may impact them individually, and how it can impact our community. They will develop an understanding of microaggressions and how our biases can help create these destructive interactions. Finally, they will explore how they can use this awareness to intervene in microaggressive interactions. 
 

--- a/04-cs-fundamentals/internship/Arrays-LinkedLists.md
+++ b/04-cs-fundamentals/internship/Arrays-LinkedLists.md
@@ -64,7 +64,7 @@ Design and implement pseudo code for functions to do the following:
 + [Memory leak](https://en.wikipedia.org/wiki/Memory_leak)
 + [Access Violation](https://en.wikipedia.org/wiki/Segmentation_fault)
 
-##Slide Deck
+## Slide Deck
 + Slide Deck used in class</br>
 <span xmlns:dct="http://purl.org/dc/terms/" property="dct:title"><a href="https://www.slideshare.net/secret/K2Ui5jdn6QjW47">Arrays and Linked Lists</a></span> is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-nc-nd/4.0/">Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International License</a>.</br>
 <a rel="license" href="http://creativecommons.org/licenses/by-nc-nd/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-nd/4.0/88x31.png" /></a><br /> Please use the <strong>Download</strong> button and play the slide deck locally. Without this, the animations which are necessary in understanding the solutions will not render properly.

--- a/04-cs-fundamentals/internship/Binary Search Trees.md
+++ b/04-cs-fundamentals/internship/Binary Search Trees.md
@@ -54,7 +54,7 @@ Here's the problems we'll cover in class. Design and implement code for function
 
 <b>Note</b>: Assume each Node in the tree has integer data and links to the left Node and the right Node. </br>
 
-##Slide Deck
+## Slide Deck
 + Slide Deck used in class</br>
 <span xmlns:dct="http://purl.org/dc/terms/" property="dct:title"><a href="https://www.slideshare.net/secret/1BRYeQtfdLjeus">Binary Search Trees</a></span> is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-nc-nd/4.0/">Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International License</a>.</br>
 <a rel="license" href="http://creativecommons.org/licenses/by-nc-nd/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-nd/4.0/88x31.png" /></a><br /> Please use the Download button and play the slide deck locally. Without this, the animations which are necessary in understanding the solutions will not render properly.

--- a/04-cs-fundamentals/internship/Stacks and Queues.md
+++ b/04-cs-fundamentals/internship/Stacks and Queues.md
@@ -51,7 +51,7 @@ Design and implement pseudo code for:
 + 3. Write a function to reverse a string (the funciton takes a string as input parameter) using a Stack.
 </br>
 
-##Slide deck
+## Slide deck
 + Slide deck used in class</br>
 <span xmlns:dct="http://purl.org/dc/terms/" property="dct:title"><a href="https://www.slideshare.net/secret/mYt7lab98fGApm">Stacks and Queues</a></span> is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-nc-nd/4.0/">Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International License</a>.</br>
 <a rel="license" href="http://creativecommons.org/licenses/by-nc-nd/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-nd/4.0/88x31.png" /></a><br />

--- a/05-html-css/00-alt-text.md
+++ b/05-html-css/00-alt-text.md
@@ -1,13 +1,13 @@
-#Alternate Text
+# Alternate Text
 
 Alternate text, or alt text, provides a textual alternative to non-text content in web pages. Most commonly seen as an attribute of `<img>` elements (`<img alt="descriptive text" src="photo-file.png">`). Alt text can also be presented in the context of the image itself (in a `<figcaption` for example).
 
-##Functions of alt text:
+## Functions of alt text:
 - Alt text is important for folks who use screen readers to understand the context and content of all elements in a website.
 - Alt text shows up in place of an image if the image fails to load or the user has chosen to disable images.
 - Alt text provides semantic meaning for internet spiders to accurately assess the contents of a site, which is helpful for SEO.
 
-##How to write good alt text:
+## How to write good alt text:
 - Describes content AND function
 - Concise and not redundant
 - If text in the alt attribute is unnecessary, you *must* still use the alt attribute, but with an empty string:
@@ -21,12 +21,12 @@ Let's do a few examples for funs, then we'll get into more detail:
 
 ![""](https://pbs.twimg.com/media/B59UpYnCAAETNMI.jpg)
 
-##More on good alt text:
+## More on good alt text:
 - The context of the image is everything
   - Is the image purely decorative?
   - Does image convey information important to the associated content?
   - Is the image linked?
 - There is no need to say 'link to...' or 'image of...'. The screen reader will announce this based on the tag.
 
-##More examples, this time from the internets:
+## More examples, this time from the internets:
 [Examples from WebAIM]http://webaim.org/techniques/alttext/

--- a/05-html-css/00-css-intro.md
+++ b/05-html-css/00-css-intro.md
@@ -100,7 +100,7 @@ Many properties require some measure of size (font-size, width, etc). There are 
 
 ## Common Properties
 
-###Font Properties###
+### Font Properties
 
 - font-size: a number followed by a measurement of how tall the element's text is, usually in ems (em) or pixels (px)
 - font-family: the name of a typeface, or typefaces
@@ -110,14 +110,14 @@ Many properties require some measure of size (font-size, width, etc). There are 
 measurement of how tall the element's line of is,
 usually in ems (em) or pixels (px)
 
-###Text Properties###
+### Text Properties
 
 - text-align: left | right | center | justify
 - text-transform: capitalize | uppercase | lowercase | some others
 - text-decoration: underline | overline | line-through | some others
 - Note: A lot of properties will take a value of none
 
-###Colors###
+### Colors
 
 - To set text colors, the property is color
 - To set background colors, the property is background-color

--- a/05-html-css/00-floats-sundry.md
+++ b/05-html-css/00-floats-sundry.md
@@ -1,8 +1,8 @@
-#Intro To Position: Floats
+# Intro To Position: Floats
 
 But first, a couple of sundries.
 
-##Colors
+## Colors
 
 CSS colors are all made by mixing different levels of red, green, and blue, though there are multiple ways to represent this.
 
@@ -32,7 +32,7 @@ CSS colors are all made by mixing different levels of red, green, and blue, thou
 
 There are a number of color pickers online for hex and rgb colors, as well as sites that will convert color values.
 
-##The Box Model
+## The Box Model
 Every element on the page is a rectangular box and many properties determine its size: size of the core box, padding, border, and margin.
 
 ![css box model](https://developer.apple.com/library/mac/documentation/AppleApplications/Conceptual/Safari_Developer_Guide/Art/box_model_metrics_2x.png)
@@ -46,25 +46,25 @@ Important: The sizes of padding, border, and margin _add to_ the defined size of
 ```
 
 
-##Positioning With Floats
+## Positioning With Floats
 
-###What Floats Do
+### What Floats Do
 - Floating an object takes it out of the normal flow of the HTML.
 - Elements can only be floated left or right, and cannot be centered with floats.
 - Floated boxes will move to the left or right until their outer edge touches the containing block edge or the outer edge of another float.
 - The elements after the floating element will flow around it.
 - The elements before the floating element will not be affected.
 
-####Syntax
+#### Syntax
 `selector {float: value;}`
 Possible values are `left`, `right`, `none`.
 
 
-###Clearing Floats
+### Clearing Floats
 When you want other content from flowing around the floated items, apply the `clear` property to the element you want to not flow around floated items.
 
 
-####Syntax
+#### Syntax
 `selector {clear: value;}`
 Possible values are `left`, `right`, `both`, or `none`.
 
@@ -75,7 +75,7 @@ https://css-tricks.com/all-about-floats/
 https://www.smashingmagazine.com/2007/05/css-float-theory-things-you-should-know/
 
 
-###Clearfix
+### Clearfix
 
 When a container box has only floated elements in it, the container height collapses to zero. Since floated boxes are taken out of the flow and don’t affect the parent box, there is nothing to give height to the container. If you want a border or background around your floated elements, this will cause problems.
 

--- a/05-html-css/00-html-divide-conquer.md
+++ b/05-html-css/00-html-divide-conquer.md
@@ -1,4 +1,4 @@
-#Divide & Conquer
+# Divide & Conquer
 
 - `<ol>` vs `<ul>`
 - `<head>` vs `<header>`

--- a/05-html-css/00-semantics-best-practices.md
+++ b/05-html-css/00-semantics-best-practices.md
@@ -11,7 +11,7 @@
   - For specific elements
 
 
-###A Few Words on Web Accessibility
+### A Few Words on Web Accessibility
 Web accessibility is quickly garnering awareness among developers, many of whom are hadn't realized the importance, scope, or sheer number of folks who need it. What this means is that many developers don't know how to implement techniques for accessibility well or quickly. This in turn means it's easy to get set aside to do later, and then set aside for financial and time reasons.
 
 However. Approximately 20% of Americans have a disability that could affect their ability to access many websites, and an accessible site benefits everyone.
@@ -64,7 +64,7 @@ They're both HTML, but HTML5 is the latest version of it. There is a working gro
 HTML5 adds a number of semantic elements like `<nav>, <aside>, <article>, <footer>, <address>` and a number of elements to better handle multimedia content.
 
 
-####Block Level vs. Inline elements
+#### Block Level vs. Inline elements
 Block-level elements occupy the entire space of its parent element (container), thereby creating a "block."
 
 Inline elements occupy only the space bounded by the tags that define the inline element.
@@ -136,7 +136,7 @@ Don't use headings to just make the text bigger or bold. Use them to add meaning
 <h3>No super powers
 
 
-####Other Semantic Elements
+#### Other Semantic Elements
 - `<p>`: Block level paragraph element. Used for chunks of text, often following a header element.
 - `<header>`: Used as an element to hold page header information (logo, navigation, heading)
 - `<nav>`: Used as a container for navigational links
@@ -154,7 +154,7 @@ Don't use headings to just make the text bigger or bold. Use them to add meaning
 </figure>
 ```
 
-####A Few Non-Semantic Elements
+#### A Few Non-Semantic Elements
 
 
 `div`, and `span` are purely for building the structure of the site, they don't have any semantic meaning. `div` tags are for content that really doesn't have a semantic counterpart. Avoid relying on divs. `span` tags are used to highlight/emphasize or otherwise identify small, inline pieces of content.
@@ -163,7 +163,7 @@ Don't use headings to just make the text bigger or bold. Use them to add meaning
 <span>I'm a span!</span>
 ```
 
-####One Example of Semantic v. Non-Semantic Code
+#### One Example of Semantic v. Non-Semantic Code
 
 
 - `<b>`: Inline level element to make text bold.`</b>`

--- a/05-html-css/00a-css-divide-conquer.md
+++ b/05-html-css/00a-css-divide-conquer.md
@@ -1,4 +1,4 @@
-#Divide and Conquer:
+# Divide and Conquer:
 Include a few useful values, as well as any shorthand that's applicable
 - text-align, text-transform, and text-decoration
 - padding v margin

--- a/05-html-css/00b-css-practice.md
+++ b/05-html-css/00b-css-practice.md
@@ -1,4 +1,4 @@
-#Practice Ideas:
+# Practice Ideas:
 
 
 - H3 headlines are larger than H1s

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Textbook Curriculum
 This is a holding pen for curriculum. More forthcoming.
 
-##How to Volunteer
+## How to Volunteer
 Want to get involved? Yay! [Volunteer with Ada Developers Academy](http://adadevelopersacademy.wiki/)
 
 ## This Curriculum is Licensed Creative Commons Attribution-ShareAlike 4.0


### PR DESCRIPTION
## Description
Recently GitHub decided to [create a formal spec](https://github.com/blog/2333-a-formal-spec-for-github-flavored-markdown) for GitHub Flavored Markdown.

One side effect of this, and the resulting updates to their Markdown parser & renderer, is that specifying a header without a space or new line following the hash characters will [create a paragraph instead](https://github.github.com/gfm/#example-34).

Apparently this was always invalid, but GitHub's earlier implementation allowed it so they decided to break backwards compatibility. As a result, I've updated our textbook repository in all instances where we used the invalid syntax.

## Todos
- [ ] Update Jump Start
- [ ] Update project repos
- [ ] Update misc. other repos

## Feedback Requested
I found the updated lines with automated searching, and changed them with automated substitution regular expressions.

If you find that you've an abundance of free time and very little direction for how to spend it, perhaps try gardening? Failing that, you could check through all of our curriculum manually to see if I missed anything.
