### PR TITLE
Updates to OAuth Testing Resource

### DIFF
--- a/09-intermediate-rails/testing-auth.md
+++ b/09-intermediate-rails/testing-auth.md
@@ -28,7 +28,9 @@ Because our integration tests are going to run code from all areas of our Rails 
 
 Specifically, we need to write our integration tests _in the role of the **browser**_. That is, our integration tests simulate a browser accessing our site by making HTTP requests to the server. Just like the browser, our test code is limited to making those requests and asserting various things about the response received back.
 
-In particular, this means we cannot modify the `session` directly from our tests. Instead we do what the browser would do: send another request.
+In particular, this means we cannot modify the `session` or `flash` directly from our tests. Instead we do what the browser would do: send another request.
+
+Note that we can *read* `session` and `flash` *after* a request has been sent, to check they were filled in correctly. It is only attempting to *set* them from a controller test that Rails disallows. This will be important later when we're checking error messages.
 
 ## Integration Tests and OAuth
 
@@ -49,14 +51,14 @@ To resolve these issues, we'll use a strategy known as **mocking**. The basic id
 
 Here is how we are going to approach this problem:
 
-1. Set up our test suite to mock OmniAuth so we don't try to connect directly to GitHub
-1. Simulate a session which will set up the `auth_hash` for use in testing the login process in the `SessionsController`
-1. Simulate sessions for logged-in users and guest users to test other controller actions
+1. Tell OmniAuth to use mock data instead of connecting to GitHub
+1. Define some test fixtures for the `User` model
+1. Define a `login` function for our tests that sends the login request using fixture data
+1. Test controller actions that require login!
 
-#### Test Setup
-Tests shouldn't be dependent on external objects or network connections in order to run. We know that when we implemented OAuth using the OmniAuth gem that we have introduced a dependency on Github.
+#### Turn on Mocking
 
-To be able to mock the interaction with Github, add these two functions to the `ActiveSupport::TestCase` class in `test/test_helper.rb`:
+To be able to mock the interaction with Github, add this function to the `ActiveSupport::TestCase` class in `test/test_helper.rb`:
 
 ```ruby
 # test/test_helper.rb
@@ -71,158 +73,258 @@ class ActiveSupport::TestCase
     # to OmniAuth will be short circuited to use the mock authentication hash.
     # A request to /auth/provider will redirect immediately to /auth/provider/callback.
     OmniAuth.config.test_mode = true
-
-    # The mock_auth configuration allows you to set per-provider (or default) authentication
-    # hashes to return during testing.
-    OmniAuth.config.mock_auth[:github] = OmniAuth::AuthHash.new({
-      provider: 'github', uid: '123545', info: { email: "a@b.com", nickname: "Ada" }
-      })
   end
+end
+```
 
-  def login
-    # Requires the auth callback to be a named route
-    get auth_callback_path("github"), env: {
-      'omniauth.auth' => OmniAuth.config.mock_auth[:github]
+The `setup` method defined here will be run once, before all tests. All of our `describe` blocks will "inherit" from this class, so the setup code will be applied to them too.
+
+#### Define Test Fixtures
+
+These test fixtures are very similar to those we've made in the past. The only difference is in how we'll use them, not in how they are defined. Make sure the field names match the schema for your User model (this may differ slightly between Stacks and Queues).
+
+<!-- TODO: Add yml highlighting before finishing -->
+```
+ada:
+  oauth_provider: github
+  oauth_uid: 12345
+  email: ada@adadevelopersacademy.org
+  username: countess_ada
+
+grace:
+  oauth_provider: github
+  oauth_uid: 13371337
+  email: grace@hooper.net
+  username: graceful_hoops
+```
+
+#### Logging In
+
+Next, we need to use this information to log in. We'll start by testing the auth callback itself, which will allow us to exercise this functionality in isolation.
+
+**Question:** What interesting test cases can you think of for the auth callback? Hint: there are at least 3.
+
+##### Building the Auth Hash
+
+In order to log in a user, we'll need to provide data to our controller in the exact same format as GitHub does. To make this process easy, we'll create an instance method for the User model, `User#mock_auth_hash`. This method will be almost the opposite of the `from_github` method we defined when we set up OAuth in the first place.
+
+```ruby
+# app/models/user.rb
+class User < ApplicationRecord
+  # ...
+  # Whatever was here before (relations, validations, etc.)
+  # ...
+
+  # Test helper method to generate a mock auth hash
+  # for fixture data
+  def mock_auth_hash
+    return {
+      provider: self.oauth_provider,
+      uid: self.oauth_uid,
+      info: {
+        email: self.email,
+        nickname: self.username
+      }
     }
   end
 end
 ```
 
-The above code will populate the **default** OmniAuth request data hash with the information that you have provided here. This is especially useful and necessary when you are testing controller actions that may require a user to be logged in. This is mock data which should match what we may expect to see from the _real_ `auth_hash` we'll get back from GitHub. This is setting up the **default** data and nothing more. We'll need to _use_ this data in our tests in the next step.
+##### Test: Returning User
 
-#### Session Tests
-
-First, let's create a method which will allow us to log in using the default OmniAuth data that we just configured.
+Now the test itself:
 
 ```ruby
-# sessions_controller_test.rb
-describe SessionsController do
-  def login
-    open_session do |sess|
-      sess.get auth_github_callback_path, env: { # using our app's callback route
-        'omniauth.auth' => OmniAuth.config.mock_auth[:github] # using the configuration we added above
-      }
+# test/controllers/users_controller_test.rb
+require "test_helper"
+
+describe UsersController do
+  describe "auth_callback" do
+    it "logs in an existing user and redirects to the root route" do
+      # Count the users, to make sure we're not (for example) creating
+      # a new user every time we get a login request
+      start_count = User.count
+
+      # Get a user from the fixtures
+      user = users(:grace)
+
+      # Tell OmniAuth to use this user's info when it sees
+      # an auth callback from github
+      OmniAuth.config.mock_auth[:github] = OmniAuth::AuthHash.new(user.mock_auth_hash)
+
+      # Send a login request for that user
+      # Note that we're using the named path for the callback, as defined
+      # in the `as:` clause in `config/routes.rb`
+      get auth_callback_path(:github)
+
+      must_redirect_to root_path
+
+      # Should *not* have created a new user
+      User.count.must_equal start_count
+    end
+
+    it "creates an account for a new user and redirects to the root route" do
+    end
+
+    it "redirects to the login route if given invalid user data" do
     end
   end
 end
 ```
 
-There is a lot of new syntax here, but the idea is that we are creating a new session specifically for this user. The `login` method will return this session to the caller (which will be our test) and then we can use this session variable to create our assertions like we've done in other controller tests.
+**Question:** What do the other two tests for this controller action look like?
 
-Then you can test your session controller like this:
-
-```ruby
-# sessions_controller_test.rb
-...
-  it "can create/login a user" do
-    user_session = login       # calling the method we just created
-    user_session.must_redirect_to root_path
-    user_session.flash[:success].must_equal "Logged in successfully!"
-  end
-```
-
-The main difference you'll notice with this assertion is that we are now using the dot notation to call the `must_redirect_to` and retrieve the `flash`. This is because the login action is now tied to a specific user's session and the general request that we tied onto before is no longer available.
-
-We can extend this further to assert that upon initial login, this action will create a new user in the database.
-```ruby
-# sessions_controller_test.rb
-...
-  it "can create/login a user" do
-    proc {
-      user_session = login       # calling the method we just created
-      user_session.must_redirect_to root_path
-      user_session.flash[:success].must_equal "Logged in successfully!"
-    }.must_change 'User.count', 1
-  end
-```
-
-Another test we may want to add is an assertion that it will not create a new user when a user is logging in for a second time.
-```ruby
-# sessions_controller_test.rb
-...
-  it "doesn't create a new user on repeat login" do
-    proc {
-      first_session = login   # throwaway variable
-      second_session = login
-      second_session.must_redirect_to root_path
-    }.must_cange 'User.count', 1  # will increase by only one from the first login
-  end
-```
-
-**Question**: How might we extend our `login` method to allow us to specify our own data in the auth hash instead of just the default?
-
-#### Controller Tests
-
-Now that we've verified that our sessions controller works as expected, we want to take a look at our existing controller tests. Right now, all of the tests we wrote prior to implementing the sessions controller are broken because we are not allowing those actions to happen until the user has logged in.
-
-Now we want to have two different sections (`describe` blocks) of tests: one for the logged-in user functionality and one for the guest user functionality.
+##### Test: New User
 
 ```ruby
-# books_controller_test.rb
-...
-describe "Logged in user actions" do
-  # most of our existing tests go here since they
-  # assume a logged-in user
-end
+it "creates a new user" do
+  start_count = User.count
+  user = User.new(oauth_provider: "github", oauth_uid: 99999, username: "test_user", email: "test@user.com")
 
-describe "Guest user actions" do
-  # we allow only the book index page for our guest users
-  # so we'll want to verify the redirect to root and message for these
+  OmniAuth.config.mock_auth[:github] = OmniAuth::AuthHash.new(user.mock_auth_hash)
+  get auth_callback_path(:github)
+
+  must_redirect_to root_path
+
+  # Should have created a new user
+  User.count.must_equal start_count + 1
 end
 ```
 
-##### Logged In Users
-Let's start with the logged in user actions section. We want to simulate the session in the same way we did for our session tests using the `login` method, and use our existing assertions to ensure that the behavior is the same.
+**Question:** Why did we create a new `User` here? Do you notice any repeated code?
+
+#### Login Helper
+
+We're going to be using this login functionality a lot, so let's add it as a helper method, available to all our tests. Open up `test/test_helper.rb` again and add the following at the bottom of `class ActiveSupport::TestCase`, after the `setup` method we added earlier:
+
+```ruby
+# test/test_helper.rb
+def login(user)
+  OmniAuth.config.mock_auth[:github] = OmniAuth::AuthHash.new(user.mock_auth_hash)
+  get auth_callback_path(:github)
+end
+```
+
+This method takes a `User`, tells OmniAuth to use that user's data as it's mock auth hash, and then sends the login request, exactly like we did in our tests above.
+
+Refactoring our returning user test above to use this method, it would look like:
+
+```ruby
+# test/controllers/users_controller_test.rb
+it "logs in an existing user" do
+  start_count = User.count
+
+  login(users(:grace))
+  must_redirect_to root_path
+
+  # Should *not* have created a new user
+  User.count.must_equal start_count
+end
+```
+
+Much neater!
+
+### Interacting with Books
+
+Recall that last time we added a line like the following to `BooksController`:
+
+```ruby
+before_action :require_login, except [:index]
+```
+
+This made it impossible for a user to do anything but list books before logging in. If you really think about it, this actually gives us two bits of functionality for each action:
+- If the user is logged in, they can do a thing to a book
+- If the user is **not** logged in, when they attempt to do a thing to a book they get redirected to the root path with an error message
+
+This new functionality means we need a new test case for each controller action, to verify access is correctly restricted.
+
+To accomplish this, let's start by splitting our books tests in two using nested describe blocks:
 
 ```ruby
 # books_controller_test.rb
-...
-  describe "Logged in user actions" do
-      def login
-        open_session do |sess|
-          sess.get auth_github_callback_path, env: {
-            'omniauth.auth' => OmniAuth.config.mock_auth[:github]
-          }
-        end
-      end
-
-      before do
-        @session = login
-      end
-    ...
+describe BooksController do
+  describe "Logged in users" do
+    # most of our existing tests go here since they
+    # assume a logged-in user
   end
-```
 
-Now, within our existing tests, we'll want to use the `@session` variable to reference our session. This will ensure that we're testing the full integration now with the logged-in user.
-
-Here is one example of the updated test:
-```ruby
-# books_controller_test.rb
-...
-      it "should show one book" do
-        @session.get book_path(books(:venetia).id)
-        @session.must_respond_with :success
-      end
-```
-
-##### Guest Users
-Using controller testing syntax we've learned before, we can write tests to ensure we can see the books index page. A potentially more interesting test will verify that when attempting to view a page that the user is not authorized to view, our application will redirect and show a message to the user.
-
-Here is one example of that type of test:
-```ruby
-# books_controller_test.rb
-...
-  describe "Guest user actions" do
-      it "should not allow you to see books details if not logged in" do
-        get book_path(books(:POODR).id)
-        # if they are not logged in they cannot see the resource and are redirected to login.
-        must_redirect_to root_path
-        flash[:warning].must_equal "You must be logged in to view this page"
-      end
-    ...
+  describe "Guest users" do
+    # we allow only the book index page for our guest users
+    # so we'll want to verify the redirect to root and message for these
   end
+end
 ```
+
+#### Logged In Users
+
+These tests require the user to be logged in. We can accomplish this using a `before` block, which will run before every test:
+
+```ruby
+# books_controller_test.rb
+describe BooksController do
+  describe "Logged in users" do
+    before do
+      login(users(:grace))
+    end
+
+    describe "show" do
+      # Just the standard show tests
+      it "succeeds for a book that exists" do
+        book_id = Book.first.id
+        get book_path(book_id)
+        must_respond_with :success
+      end
+
+      it "returns 404 not_found for a book that D.N.E." do
+        book_id = Book.last.id + 1
+        get book_path(book_id)
+        must_respond_with :not_found
+      end
+    end
+
+    # ...
+    # Tests for other actions
+    # ...
+  end
+
+  describe "Guest users" do
+  end
+end
+```
+
+#### Guest Users
+
+For our guest users, we need to verify that access is restricted to everything but `index`.
+
+```ruby
+# books_controller_test.rb
+describe BooksController do
+  describe "Logged in users" do
+    # See above section
+  end
+
+  describe "Guest users" do
+    it "can access the index" do
+      get books_path
+      must_respond_with :success
+    end
+
+    it "cannot access new" do
+      get new_book_path
+      must_redirect_to root_path
+      flash[:message].must_equal "You must be logged in to see that page!"
+    end
+
+    # ...
+    # Similarly for other controller actions
+    # ...
+  end
+end
+```
+
+## What Did We Accomplish?
 
 ## Additional Resources
 - [OmniAuth Integration Testing](https://github.com/omniauth/omniauth/wiki/Integration-Testing)
 - [Integration Testing Docs](http://api.rubyonrails.org/classes/ActionDispatch/IntegrationTest.html)
+- [DHH on mutating `session` in Rails 5](https://github.com/rails/rails/issues/23386)


### PR DESCRIPTION
## Description
Removed all that junk about keeping track of a session in the test! Turns out you don't need it.

Substantially modified the way we interact with the mock data. We now set it explicitly before every login request, and the `login` helper function now takes a `User` object to log in as. That should enable some nice testing around multi-user interaction, should students find the time. Also, turns out the request was completely ignoring the `env` argument, so I've removed it for simplicity.

Added `What Did We Accomplish` section at the bottom, because this is a big sucker and I'll probably have forgotten what all we did by the time I'm done teaching it.

### Warning
All the code snippets I used, particularly those interacting with the model, reflect the books oauth strategy and migrations and such we did in the Queues classroom. YMMV if you copy/paste.

## Todos
N/A

## Feedback Requested
Anything you've got time for.