### PR TITLE
Typo?

### DIFF
--- a/09-intermediate-rails/xx-consuming-apis-in-rails.md
+++ b/09-intermediate-rails/xx-consuming-apis-in-rails.md
@@ -115,7 +115,7 @@ module SlackMkii
 end
 ```
 
-And that should do it. To verify it worked, spin up the rails console, and run `SlackWrapper.new`. It should return a new instance of SlackWrapper, instead of throwing an error.
+And that should do it. To verify it worked, spin up the rails console, and run `SlackAPIWrapper.new`. It should return a new instance of SlackAPIWrapper, instead of throwing an error.
 
 You'll have to restart the rails server in order for it to load the new library.
 

--- a/09-intermediate-rails/xx-consuming-apis-in-rails.md
+++ b/09-intermediate-rails/xx-consuming-apis-in-rails.md
@@ -115,7 +115,7 @@ module SlackMkii
 end
 ```
 
-And that should do it. To verify it worked, spin up the rails console, and run `SlackAPIWrapper.new`. It should return a new instance of SlackAPIWrapper, instead of throwing an error.
+And that should do it. To verify it worked, spin up the rails console, and run `SlackApiWrapper.new`. It should return a new instance of SlackApiWrapper, instead of throwing an error.
 
 You'll have to restart the rails server in order for it to load the new library.
 


### PR DESCRIPTION
## Description
A few sentences describing the overall purpose of these textbook changes.
Typo I believe.  The class is named SlackApiWrapper not SlackWrapper.
## Todos
Are any of these items still in progress?
- [ ] Section X still needs some more detailed examples
- [ ] Still need to add "Additional Resources"

## Feedback Requested
Please utilize the built-in GitHub Reviewers functionality to assign necessary reviewers. Use this section to further specify portions of the PR that you would like additional or focused feedback on.
