### PR TITLE
turn off i18n features for the money gem example

### DIFF
--- a/01-ruby-fundamentals/intro-to-ruby-gems.md
+++ b/01-ruby-fundamentals/intro-to-ruby-gems.md
@@ -22,6 +22,10 @@ Generally the github page for a gem is the best place to go to get started. Let'
 ```ruby
 require 'money'
 
+# We're not going to use internationalization features for this example.
+# To learn more about internationalization in this gem, visit https://github.com/RubyMoney/money
+Money.use_i18n = false
+
 # 10.00 USD
 money = Money.new(1000, "USD")
 money.cents     #=> 1000


### PR DESCRIPTION
## Description
Default use of the money gem will look for internationalization/locale config, and produce the following error:
```
`enforce_available_locales!': :en is not a valid locale (I18n::InvalidLocale)
```

For this example, turn off internationalization

## Todos

## Feedback Requested
