### PR TITLE
Cleanup the Backbone section's README

### DIFF
--- a/11-Backbonejs/README.md
+++ b/11-Backbonejs/README.md
@@ -15,9 +15,3 @@
 
 ### Wednesday
 1. Advanced Model stuff (TODO DPR)
-
-### Week 2
-1. Views
-1. Custom Events
-1. Testing
-1. ... the router? probably not

--- a/11-Backbonejs/README.md
+++ b/11-Backbonejs/README.md
@@ -1,7 +1,7 @@
 
 # Backbone
 
-## New order
+## Week 1
 ### Monday
 1. [Underscore Templates](../10-JavaScript/underscore-templates.md)
 1. [Intro to Backbone](Introduction-to-Backbonejs.md)
@@ -21,16 +21,3 @@
 1. Custom Events
 1. Testing
 1. ... the router? probably not
-
-## Old Order
-### Part 1: Models and Collections
-1.  [Intro to Backbone](Introduction-to-Backbonejs.md)
-1.  [Backbone Models](Backbone-Models.md)
-1.  [Backbone Collections](Backbone-Collections.md)
-1.  [Enhancing the Model](Enhancing-the-model.md)
-1.  [Backbone Views](Backbone-Views.md)
-1.  [Views for A Collection](Views-of-Collections.md)
-
-### Part 2
-1.  [Backbone APIs](Backbone-APIs.md)
-1.  [Backbone Advanced Collections](Backbone-Advanced-Collections.md)


### PR DESCRIPTION
## Description
* Took out the "old order" section because we don't need to have it alongside the new stuff.
* Also took out the week 2 section, we should add it back with whatever PR actually updates those curriculum items, or when the schedule is determined.

**NOTE**: Chris' updates (#341) for advanced models & collections curriculum also updates `README.md`, so we should get that PR merged in first and then I can fix any resulting conflicts for this PR afterwards.

## Todos
- [ ] Consider whether we should really be breaking the curriculum items into specific days... we've been burned by making our organization info too schedule-specific before.
