### PR TITLE
Update Simplecov to not reference Robot Name WW

### DIFF
--- a/00-programming-fundamentals/code-coverage-and-simplecov.md
+++ b/00-programming-fundamentals/code-coverage-and-simplecov.md
@@ -102,7 +102,7 @@ Some teams require a certain percentage of code coverage and it's likely you wil
 
 ### Exercise
 
-Add code coverage to your Robot Name Weekend-Warrior exercise.      
+Add code coverage to your Deck & Card TDD Exercise.      
 
 
 ## Spec Helpers


### PR DESCRIPTION
## Description
We haven't assigned Robot Name yet and the SimpleCov lecture references it.  I've changed it to reference the TDD exercise.  

## Questions for the Author
- [ x ] Have you updated the weekly learning goals in the pedagogy resource

## Todos
Are any of these items still in progress?
- Nope

## Feedback Requested
Please utilize the built-in GitHub Reviewers functionality to assign necessary reviewers. Use this section to further specify portions of the PR that you would like additional or focused feedback on.
