### PR TITLE
HTML forms: Minor changes to input and label elements

### DIFF
--- a/05-html-css/exercises/form_exercise.md
+++ b/05-html-css/exercises/form_exercise.md
@@ -65,9 +65,16 @@ To save you a little typing, here are tags for the dropdown menu and the radio b
 
 <label for="material">Product Material</label>
 <div>
-  <input name="material" type="radio" value="horsehair">
-  <input name="material" type="radio" value="nylon">
-  <input name="material" type="radio" value="polyester">
-  <input name="material" type="radio" value="n-a">
+  <input id="material-horsehair" name="material" type="radio" value="horsehair">
+  <label for="material-horsehair">Natural Horsehair</label>
+
+  <input id="material-nylon" name="material" type="radio" value="nylon">
+  <label for="material-nylon">Synthetic Nylon</label>
+
+  <input id="material-polyester" name="material" type="radio" value="polyester">
+  <label for="material-polyester">Synthetic Polyester</label>
+
+  <input id="material-n-a" name="material" type="radio" value="n-a">
+  <label for="material-n-a">N/A</label>
 </div>
 ```

--- a/05-html-css/exercises/form_exercise.md
+++ b/05-html-css/exercises/form_exercise.md
@@ -65,9 +65,9 @@ To save you a little typing, here are tags for the dropdown menu and the radio b
 
 <label for="material">Product Material</label>
 <div>
-  <input name="material" type="radio" value="horsehair">Natural Horsehair</input>
-  <input name="material" type="radio" value="nylon">Synthetic Nylon</input>
-  <input name="material" type="radio" value="polyester">Synthetic Polyester</input>
-  <input name="material" type="radio" value="n-a">N/A</input>
+  <input name="material" type="radio" value="horsehair">
+  <input name="material" type="radio" value="nylon">
+  <input name="material" type="radio" value="polyester">
+  <input name="material" type="radio" value="n-a">
 </div>
 ```

--- a/05-html-css/html-forms.md
+++ b/05-html-css/html-forms.md
@@ -169,4 +169,5 @@ Second, it sends that data over the internet to the address specified by the `<f
 ## Resources
 - [MDN Input Element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input)
 - [MDN Form Element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form)
+- [MDN Label Element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/label)
 - [SO on why `<textarea>` isn't `<input type="textarea">`](https://stackoverflow.com/questions/5637326/why-isnt-textarea-an-inputtype-textarea)

--- a/05-html-css/html-forms.md
+++ b/05-html-css/html-forms.md
@@ -83,7 +83,7 @@ Let's add a few `<input>` elements to our email signup form. Since `<input>` is 
 
 One thing you'll notice about our example so far is that it doesn't include any text on the page. There's no indication (other than the placeholder text) of what our `<input>` elements are for. To help out the user we'll label them with `<label>`s.
 
-Each `<label>` gets a `for` attribute, which should match the `name` of the `<input>` it corresponds to. Making this connection is important for accessibility.
+Each `<label>` gets a `for` attribute, which should match the `id` of the `<input>` it corresponds to. Making this connection is important for accessibility.
 
 Adding `<label>` tags to our example yields:
 
@@ -92,12 +92,12 @@ Adding `<label>` tags to our example yields:
 <form action="/newsletter/signup" method="post">
   <div>
     <label for="email">Your email:</label>
-    <input name="email" type="text" placeholder="lovelace@adadev.org">
+    <input id="email" name="email" type="text" placeholder="lovelace@adadev.org">
   </div>
 
   <div>
     <label for="name">Your name:</label>
-    <input name="name" type="text" placeholder="Ada Lovelace">
+    <input id="name" name="name" type="text" placeholder="Ada Lovelace">
   </div>
 
   <input type="submit" value="Sign up now!">
@@ -121,17 +121,17 @@ Let's add a `<select>` dropdown menu to our email signup form:
 <form action="/newsletter/signup" method="post">
   <div>
     <label for="email">Your email:</label>
-    <input name="email" type="text" placeholder="lovelace@adadev.org">
+    <input id="email" name="email" type="text" placeholder="lovelace@adadev.org">
   </div>
 
   <div>
     <label for="name">Your name:</label>
-    <input name="name" type="text" placeholder="Ada Lovelace">
+    <input id="name" name="name" type="text" placeholder="Ada Lovelace">
   </div>
 
   <div>
     <label for="source">How did you hear about us?</label>
-    <select name="source">
+    <select id="source" name="source">
       <option value="search">Found through a search engine</option>
       <option value="friend">Referred by a friend</option>
       <option value="sponsor-company">Through one of our sponsor companies</option>
@@ -161,7 +161,7 @@ Second, it sends that data over the internet to the address specified by the `<f
   - Every `<input>` needs a `name` attribute. This is the key used when data is sent
   - `<input>`s also take `value` and a `placeholder`
 - Every `<input>` should be paired with a `<label>`
-  - The `<label>`'s `for` attribute should match the `<input>`'s `name`
+  - The `<label>`'s `for` attribute should match the `<input>`'s `id`
 - `<textarea>` is used for a multiline text input
 - `<select>` is used for dropdown menus
   - Items in the menu should be wrapped in `<option>` tags, each with a `value` attribute

--- a/05-html-css/html-forms.md
+++ b/05-html-css/html-forms.md
@@ -68,14 +68,14 @@ Let's add a few `<input>` elements to our email signup form. Since `<input>` is 
 <h1>Sign up for the Ada newsletter</h1>
 <form action="/newsletter/signup" method="post">
   <div>
-    <input name="email" type="text" placeholder="lovelace@adadev.org"></input>
+    <input name="email" type="text" placeholder="lovelace@adadev.org">
   </div>
 
   <div>
-    <input name="name" type="text" placeholder="Ada Lovelace"></input>
+    <input name="name" type="text" placeholder="Ada Lovelace">
   </div>
 
-  <input type="submit" value="Sign up now!"></input>
+  <input type="submit" value="Sign up now!">
 </form>
 ```
 
@@ -92,15 +92,15 @@ Adding `<label>` tags to our example yields:
 <form action="/newsletter/signup" method="post">
   <div>
     <label for="email">Your email:</label>
-    <input name="email" type="text" placeholder="lovelace@adadev.org"></input>
+    <input name="email" type="text" placeholder="lovelace@adadev.org">
   </div>
 
   <div>
     <label for="name">Your name:</label>
-    <input name="name" type="text" placeholder="Ada Lovelace"></input>
+    <input name="name" type="text" placeholder="Ada Lovelace">
   </div>
 
-  <input type="submit" value="Sign up now!"></input>
+  <input type="submit" value="Sign up now!">
 </form>
 ```
 
@@ -121,12 +121,12 @@ Let's add a `<select>` dropdown menu to our email signup form:
 <form action="/newsletter/signup" method="post">
   <div>
     <label for="email">Your email:</label>
-    <input name="email" type="text" placeholder="lovelace@adadev.org"></input>
+    <input name="email" type="text" placeholder="lovelace@adadev.org">
   </div>
 
   <div>
     <label for="name">Your name:</label>
-    <input name="name" type="text" placeholder="Ada Lovelace"></input>
+    <input name="name" type="text" placeholder="Ada Lovelace">
   </div>
 
   <div>
@@ -138,7 +138,7 @@ Let's add a `<select>` dropdown menu to our email signup form:
     </select>
   </div>
 
-  <input type="submit" value="Sign up now!"></input>
+  <input type="submit" value="Sign up now!">
 </form>
 ```
 

--- a/05-html-css/solutions/form_exercise/contact.html
+++ b/05-html-css/solutions/form_exercise/contact.html
@@ -11,7 +11,7 @@
   <form action="index.html" method="post">
 
     <label for="brush-size">Brush Size</label>
-    <select name="brush-size">
+    <select id="brush-size" name="brush-size">
       <option value="#3 Fan Blender">#3 Fan Blender</option>
       <option value="#6 Fan Blender">#6 Fan Blender</option>
       <option value="Half Size Round">Half Size Round</option>
@@ -28,20 +28,27 @@
 
     <label for="material">Product Material</label>
     <div>
-      <input name="material" type="radio" value="horsehair">
-      <input name="material" type="radio" value="nylon">
-      <input name="material" type="radio" value="polyester">
-      <input name="material" type="radio" value="n-a">
+      <input id="material-horsehair" name="material" type="radio" value="horsehair">
+      <label for="material-horsehair">Natural Horsehair</label>
+
+      <input id="material-nylon" name="material" type="radio" value="nylon">
+      <label for="material-nylon">Synthetic Nylon</label>
+
+      <input id="material-polyester" name="material" type="radio" value="polyester">
+      <label for="material-polyester">Synthetic Polyester</label>
+
+      <input id="material-n-a" name="material" type="radio" value="n-a">
+      <label for="material-n-a">N/A</label>
     </div>
 
     <label class="double-wide" for="feedback">What would you like to tell us?</label>
-    <textarea class="double-wide" name="feedback" rows="8" placeholder ="How can we help?"></textarea>
+    <textarea id="feedback" class="double-wide" name="feedback" rows="8" placeholder ="How can we help?"></textarea>
 
     <label for="customer-name">Your Name</label>
-    <input name="customer-name" type="text" placeholder="Ann Artist">
+    <input id="customer-name" name="customer-name" type="text" placeholder="Ann Artist">
 
     <label for="customer-email">Your Email</label>
-    <input name="customer-email" type="text" placeholder="you@example.com">
+    <input id="customer-email" name="customer-email" type="text" placeholder="you@example.com">
 
     <input class="double-wide" type="submit" value="Send">
   </form>

--- a/05-html-css/solutions/form_exercise/contact.html
+++ b/05-html-css/solutions/form_exercise/contact.html
@@ -28,22 +28,22 @@
 
     <label for="material">Product Material</label>
     <div>
-      <input name="material" type="radio" value="horsehair">Natural Horsehair</input>
-      <input name="material" type="radio" value="nylon">Synthetic Nylon</input>
-      <input name="material" type="radio" value="polyester">Synthetic Polyester</input>
-      <input name="material" type="radio" value="n-a">N/A</input>
+      <input name="material" type="radio" value="horsehair">
+      <input name="material" type="radio" value="nylon">
+      <input name="material" type="radio" value="polyester">
+      <input name="material" type="radio" value="n-a">
     </div>
 
     <label class="double-wide" for="feedback">What would you like to tell us?</label>
     <textarea class="double-wide" name="feedback" rows="8" placeholder ="How can we help?"></textarea>
 
     <label for="customer-name">Your Name</label>
-    <input name="customer-name" type="text" placeholder="Ann Artist"></input>
+    <input name="customer-name" type="text" placeholder="Ann Artist">
 
     <label for="customer-email">Your Email</label>
-    <input name="customer-email" type="text" placeholder="you@example.com"></input>
+    <input name="customer-email" type="text" placeholder="you@example.com">
 
-    <input class="double-wide" type="submit" value="Send"></input>
+    <input class="double-wide" type="submit" value="Send">
   </form>
 
 </body>


### PR DESCRIPTION
As it turns out, `input` elements are empty, so we can't put descriptive text within them (even if the browser will make it work). Instead we need to use labels for that in all cases.

Additionally, labels connect to input elements by matching the `for` and `id` tags, not `for`/`name`.