### PR TITLE
Add Guard to Rails templates

### DIFF
--- a/08-rails/reference/.rails-template.rb
+++ b/08-rails/reference/.rails-template.rb
@@ -14,6 +14,10 @@ gem_group :development do
 
   # Nice interactive terminal when an exception happens
   gem 'binding_of_caller'
+
+  # Automatically run our tests
+  gem 'guard'
+  gem 'guard-minitest'
 end
 
 # Add some extra minitest support
@@ -48,6 +52,20 @@ inject_into_file 'config/application.rb', after: "class Application < Rails::App
       g.javascript_engine :js
     end
   RUBY
+end
+
+create_file 'Guardfile' do
+  <<~GUARDFILE
+    guard :minitest, autorun: false, spring: true do
+      watch(%r{^app/(.+)\.rb$})                               { |m| "test/\#{m[1]}_test.rb" }
+      watch(%r{^app/controllers/application_controller\.rb$}) { 'test/controllers' }
+      watch(%r{^app/controllers/(.+)_controller\.rb$})        { |m| "test/integration/\#{m[1]}_test.rb" }
+      watch(%r{^app/views/(.+)_mailer/.+})                    { |m| "test/mailers/\#{m[1]}_mailer_test.rb" }
+      watch(%r{^lib/(.+)\.rb$})                               { |m| "test/lib/\#{m[1]}_test.rb" }
+      watch(%r{^test/.+_test\.rb$})
+      watch(%r{^test/test_helper\.rb$}) { 'test' }
+    end
+  GUARDFILE
 end
 
 # Things to do after all the gems have been installed

--- a/09-intermediate-rails/reference/.rails-template.rb
+++ b/09-intermediate-rails/reference/.rails-template.rb
@@ -26,6 +26,10 @@ unless API_MODE
 
     # Nice interactive terminal when an exception happens
     gem 'binding_of_caller'
+
+    # Automatically run our tests
+    gem 'guard'
+    gem 'guard-minitest'
   end
 end
 
@@ -70,6 +74,20 @@ inject_into_file 'config/application.rb', after: "class Application < Rails::App
     g.javascript_engine :js
   end
   RUBY
+end
+
+create_file 'Guardfile' do
+  <<~GUARDFILE
+    guard :minitest, autorun: false, spring: true do
+      watch(%r{^app/(.+)\.rb$})                               { |m| "test/\#{m[1]}_test.rb" }
+      watch(%r{^app/controllers/application_controller\.rb$}) { 'test/controllers' }
+      watch(%r{^app/controllers/(.+)_controller\.rb$})        { |m| "test/integration/\#{m[1]}_test.rb" }
+      watch(%r{^app/views/(.+)_mailer/.+})                    { |m| "test/mailers/\#{m[1]}_mailer_test.rb" }
+      watch(%r{^lib/(.+)\.rb$})                               { |m| "test/lib/\#{m[1]}_test.rb" }
+      watch(%r{^test/.+_test\.rb$})
+      watch(%r{^test/test_helper\.rb$}) { 'test' }
+    end
+  GUARDFILE
 end
 
 # Things to do after all the gems have been installed


### PR DESCRIPTION
## Description
This adds necessary setup files for Guard to our Rails templates (both the initial and advanced versions).

## Feedback Requested
I've tested this out with a new Rails project, and it seems to work fine. Feel free to test it out with any of our existing project scaffolds!