### PR TITLE
Suggested changes to Rails forms lecture

### DIFF
--- a/08-rails/rails-forms.md
+++ b/08-rails/rails-forms.md
@@ -7,7 +7,7 @@ We've [previously seen](../05-html-css/html-forms.md) how HTML forms can be used
 - Learn the benefits that `form_with` has when using an ActiveRecord model
 - Get a feel for handling form data in a _controller_
 
-## `form_with`
+## The `form_with` view helper
 Similar to how `link_to` generates an achor tag, Rails has a method to generate a form named `form_with`. On the surface, they are very similar. Both are _view helpers_ that generate HTML content, and `form_with` is used to create a form, and can tie content to a specific type of model.
 
 `form_with` generates an HTML `<form>` element.  Below is one example specifying the URL to submit the form to and the HTTP method (verb) to use in the request.
@@ -34,7 +34,7 @@ You can also add additional HTML attributes to the form with more key-value pair
 <% end %>
 ```
 
-### Common _view helpers_ for forms
+### Common view helpers for forms
 Within the `form_with` block, additional form helpers can be used to create inputs and labels.
 
 #### `text_field`

--- a/08-rails/rails-forms.md
+++ b/08-rails/rails-forms.md
@@ -38,7 +38,7 @@ If you check out the resulting HTML in the browser you will notice it generates 
 You can also add additional HTML attributes to the form with more key-value pairs.  For example if you want to add a class with the value `create-book` for the form you can do the following
 
 ```erb
-<%= form_with url: "/books", method: :post class: 'create-book' do |f| %>
+<%= form_with url: "/books", method: :post, class: 'create-book' do |f| %>
 
 <% end %>
 ```
@@ -70,7 +70,7 @@ As the name implies, the `f.submit` _view helper_ generates a submit button for 
 Results in:
 
 ```html
-<input type="submit" name="commit" value="Save Book" class="book-button" data-disable-with="Save Book">
+<input type="submit" name="commit" value="Save Book" class="book-button" data-disable-with="Save Book" />
 ```
 
 Many, many other _view helpers_ are available to help build any type of form or input. Look at the [form helper docs](https://edgeapi.rubyonrails.org/classes/ActionView/Helpers/FormHelper.html) for complete documentation.
@@ -162,7 +162,7 @@ If we submitted the `form_for` example above, the params hash would arrive in ou
 ```ruby
   {
     "book" => {
-      "author" => "J.K. Rowling" },
+      "author" => "J.K. Rowling",
       "title" => "Harry Potter and The Chamber of Secrets"
     }
   }

--- a/08-rails/rails-forms.md
+++ b/08-rails/rails-forms.md
@@ -6,9 +6,9 @@ We've [previously seen](../05-html-css/html-forms.md) how HTML forms can be used
 - Discover some useful _view helpers_ specifically for working with forms
 - Get a feel for handling form data in a _controller_
 
+## `form_with`
 Similar to how `link_to` generates an achor tag, Rails has a method to generate a form named `form_with`. On the surface, they are very similar. Both are _view helpers_ that generate HTML content, and `form_with` is used to create a form, and can tie content to a specific type of model.
 
-## `form_with`
 `form_with` generates an HTML `<form>` element.  Below is one example specifying the URL to submit the form to and the HTTP method (verb) to use in the request.
 
 ```erb

--- a/08-rails/rails-forms.md
+++ b/08-rails/rails-forms.md
@@ -18,11 +18,20 @@ Just as `link_to` generates an `<a>` element, `form_with` generates a `<form>` e
 <% end %>
 ```
 
+### A note about hidden inputs
+>When working with Rails-generated forms, you'll notice that they all include a couple of `<input>`elements with the type `hidden`. You may not have encountered this type of input before as it is primarily used when doing back-end programming, such as with Rails. The two inputs, named `utf8` and `authenticity_token` look like this:
+> ```html
+> <input name="utf8" type="hidden" value="✓">
+> <input type="hidden" name="authenticity_token" value="8k7REve8u0Mq7UdaB+awSpMZ8af/5HF7udhgzpOVblQvhy2hCYIdjbEyrVhXwY9k7Ibpcprpjxxz8dCeqi55vQ==">
+> ```
+>You can ignore both of these input elements. They are necessary for Rails to work securely, but you should not need to understand or modify them. We have omitted these elements and associated data from the code snippets throughout the rest of this document.
+
+<br>
+
 If you check out the resulting HTML in the browser you will notice it generates the following:
 
 ```html
-<form action="/books" accept-charset="UTF-8" data-remote="true" method="post"><input name="utf8" type="hidden" value="✓"><input type="hidden" name="authenticity_token" value="8k7REve8u0Mq7UdaB+awSpMZ8af/5HF7udhgzpOVblQvhy2hCYIdjbEyrVhXwY9k7Ibpcprpjxxz8dCeqi55vQ==">
-
+<form action="/books" accept-charset="UTF-8" data-remote="true" method="post">
 </form>
 ```
 
@@ -109,7 +118,7 @@ We can update the `form_with` in `views/books/new.html.erb` to:
 The resulting HTML is:
 
 ```html
-<form action="/books" accept-charset="UTF-8" data-remote="true" method="post"><input name="utf8" type="hidden" value="✓"><input type="hidden" name="authenticity_token" value="AKeeT6nk32KhwFJvZZvEkoIEMlrsCh2D7AJGygNskWLdbmL8V9p5rDofuG01vPu8/Zsqj4kH4+QmK/aaOteGiw==">
+<form action="/books" accept-charset="UTF-8" data-remote="true" method="post">
   <label for="book_title">Title</label>
   <input type="text" name="book[title]" id="book_title">
 
@@ -152,8 +161,6 @@ If we submitted the `form_for` example above, the params hash would arrive in ou
 
 ```ruby
   {
-    "utf8" => "✓",
-    "authenticity_token" => "X/be9deLjFilsqYcOVBMM5Fj1vf7OWAr1K9F97JVhbhFmp/Ig9HSp2urbytRAgIoRAupAeZczOtdwbP49R1i8w==",
     "book" => {
       "author" => "J.K. Rowling" },
       "title" => "Harry Potter and The Chamber of Secrets"

--- a/08-rails/rails-forms.md
+++ b/08-rails/rails-forms.md
@@ -55,13 +55,13 @@ The `f` parameter, known as a _form builder_, is used when with the view helpers
 `text_field` is the the method to make a common text field. The first argument it expects is the HTML name attribute. The (optional) second argument is the default value of the input. Additional HTML options can be passed in a hash. For example:
 
 ```erb
-<%= f.text_field "book[author]", "J.K. Rowling", class: "books" %>
+<%= f.text_field :author, "J.K. Rowling", class: "books" %>
 ```
 
 Results in:
 
 ```html
-<input type="text" name="book[author]" id="book_author" value="J.K. Rowling" class="books" />
+<input type="text" name="author" id="author" value="J.K. Rowling" class="books" />
 ```
 
 #### `f.submit`

--- a/08-rails/rails-forms.md
+++ b/08-rails/rails-forms.md
@@ -52,8 +52,7 @@ The Rails convention when generating forms is to specify the block with a parame
 The `f` parameter, known as a _form builder_, is used when with the view helpers for things like input elements and labels. The following are some of the view helpers available through the form builder:
 
 #### `text_field`
-`text_field` is the the method to make a common text field. The first argument
-it expects is the HTML name attribute. The second is the default value of the input. Additional HTML options can be passed in a hash. For example:
+`text_field` is the the method to make a common text field. The first argument it expects is the HTML name attribute. The (optional) second argument is the default value of the input. Additional HTML options can be passed in a hash. For example:
 
 ```erb
 <%= f.text_field "book[author]", "J.K. Rowling", class: "books" %>

--- a/08-rails/rails-forms.md
+++ b/08-rails/rails-forms.md
@@ -1,4 +1,6 @@
 # Rails Forms
+We've [previously seen](../05-html-css/html-forms.md) how HTML forms can be used to submit information to websites, and have practiced creating them by manually. In this resource we will see that Rails has support for generating custom HTML forms that work well with Rails' conventions for models, controllers, and routes.
+
 ## Learning Goals
 - Learn how to generate a form in Rails with the `form_with` method.
 - Discover some useful _view helpers_ specifically for working with forms

--- a/08-rails/rails-forms.md
+++ b/08-rails/rails-forms.md
@@ -13,9 +13,7 @@ Similar to how `link_to` generates an achor tag, Rails has a method to generate 
 Just as `link_to` generates an `<a>` element, `form_with` generates a `<form>` element.  Below is one example specifying the URL to submit the form to and the HTTP method (verb) to use in the request.
 
 ```erb
-<%= form_with url: "/books", method: :post do |f| %>
-
-<% end %>
+<%= form_with url: "/books", method: :post %>
 ```
 
 ### A note about hidden inputs
@@ -38,9 +36,7 @@ If you check out the resulting HTML in the browser you will notice it generates 
 You can also add additional HTML attributes to the form with more key-value pairs.  For example if you want to add a class with the value `create-book` for the form you can do the following
 
 ```erb
-<%= form_with url: "/books", method: :post, class: 'create-book' do |f| %>
-
-<% end %>
+<%= form_with url: "/books", method: :post, class: 'create-book' %>
 ```
 
 ### Common view helpers for forms

--- a/08-rails/rails-forms.md
+++ b/08-rails/rails-forms.md
@@ -39,6 +39,29 @@ You can also add additional HTML attributes to the form with more key-value pair
 <%= form_with url: "/books", method: :post, class: 'create-book' %>
 ```
 
+## Adding form content
+So far we have generated `<form>` elements using `form_with`, but those elements have not had any contents. You may recall that HTML forms need to be populated with inputs such as text boxes and drop-down menus, and generally have a submit button.
+
+We can use the `form_with` view helper to also generate forms with custom HTML content. For example:
+
+```erb
+<%= form_with url: "/books", method: :post do %>
+  <p>Please provide the following information to save your book to our database:</p>
+<% end %>
+```
+
+the above ERB generates the following HTML:
+
+```html
+<form action="/books" accept-charset="UTF-8" data-remote="true" method="post">
+  <p>Please provide the following information to save your book to our database:</p>
+</form>
+```
+
+_NOTE:_ Even though we're using a `do ... end` block now, it is still necessary to use `<%=` because the `form_with` method returns the generated `<form>` element. This is in contrast to how we use `each` in our view code, because the `each` method's return value is not important for the HTML, only the contents of its block.
+
+So we can put HTML inside of our form now. This means we could write the `<input>` elements necessary to complete the form's conents. However as with the form itself, Rails can help us generate our inputs.
+
 ## Common view helpers for forms
 Within the `form_with` block, additional view helpers can be used to create inputs, and labels, and submit buttons.
 
@@ -83,6 +106,8 @@ The entire form could look like:
 
 ```erb
 <%= form_with url: "/books", method: :post do |f| %>
+  <p>Please provide the following information to save your book to our database:</p>
+
   <%= f.label :title %>
   <%= f.text_field :title %>
 
@@ -109,6 +134,8 @@ We can update the `form_with` in `views/books/new.html.erb` to:
 
 ```erb
 <%= form_with model: @book do |f| %>
+  <p>Please provide the following information to save your book to our database:</p>
+
   <%= f.label :title %>
   <%= f.text_field :title %>
 
@@ -123,6 +150,8 @@ The resulting HTML is:
 
 ```html
 <form action="/books" accept-charset="UTF-8" data-remote="true" method="post">
+  <p>Please provide the following information to save your book to our database:</p>
+
   <label for="book_title">Title</label>
   <input type="text" name="book[title]" id="book_title">
 

--- a/08-rails/rails-forms.md
+++ b/08-rails/rails-forms.md
@@ -65,6 +65,7 @@ So we can put HTML inside of our form now. This means we could write the `<input
 ## Common view helpers for forms
 Within the `form_with` block, additional view helpers can be used to create inputs, and labels, and submit buttons.
 
+### The form builder
 The Rails convention when generating forms is to specify the block with a parameter named `f`, like so:
 
 ```erb
@@ -74,7 +75,7 @@ The Rails convention when generating forms is to specify the block with a parame
 
 The `f` parameter, known as a _form builder_, is used when with the view helpers for things like input elements and labels. The following are some of the view helpers available through the form builder:
 
-#### `text_field`
+### Single-line text inputs with `text_field`
 `text_field` is the the method to make a common text field. The first argument it expects is the HTML name attribute. The (optional) second argument is the default value of the input. Additional HTML options can be passed in a hash. For example:
 
 ```erb
@@ -87,7 +88,7 @@ Results in:
 <input type="text" name="author" id="author" value="J.K. Rowling" class="books" />
 ```
 
-#### `f.submit`
+### Submit buttons with `f.submit`
 As the name implies, the `f.submit` _view helper_ generates a submit button for a form created with `form_with`. It accepts two parameters, both optional. The first is the text that should appear in the button (defaults to "Submit"), and the second is a hash of HTML attributes:
 
 ```erb

--- a/08-rails/rails-forms.md
+++ b/08-rails/rails-forms.md
@@ -39,8 +39,17 @@ You can also add additional HTML attributes to the form with more key-value pair
 <%= form_with url: "/books", method: :post, class: 'create-book' %>
 ```
 
-### Common view helpers for forms
-Within the `form_with` block, additional form helpers can be used to create inputs and labels.
+## Common view helpers for forms
+Within the `form_with` block, additional view helpers can be used to create inputs, and labels, and submit buttons.
+
+The Rails convention when generating forms is to specify the block with a parameter named `f`, like so:
+
+```erb
+<%= form_with url: "/books", method: :post do |f| %>
+<% end %>
+```
+
+The `f` parameter, known as a _form builder_, is used when with the view helpers for things like input elements and labels. The following are some of the view helpers available through the form builder:
 
 #### `text_field`
 `text_field` is the the method to make a common text field. The first argument

--- a/08-rails/rails-forms.md
+++ b/08-rails/rails-forms.md
@@ -10,7 +10,7 @@ We've [previously seen](../05-html-css/html-forms.md) how HTML forms can be used
 ## The `form_with` view helper
 Similar to how `link_to` generates an achor tag, Rails has a method to generate a form named `form_with`. On the surface, they are very similar. Both are _view helpers_ that generate HTML content, and `form_with` is used to create a form, and can tie content to a specific ActiveRecord model.
 
-`form_with` generates an HTML `<form>` element.  Below is one example specifying the URL to submit the form to and the HTTP method (verb) to use in the request.
+Just as `link_to` generates an `<a>` element, `form_with` generates a `<form>` element.  Below is one example specifying the URL to submit the form to and the HTTP method (verb) to use in the request.
 
 ```erb
 <%= form_with url: "/books", method: :post do |f| %>

--- a/08-rails/rails-forms.md
+++ b/08-rails/rails-forms.md
@@ -102,7 +102,8 @@ Results in:
 
 Many, many other _view helpers_ are available to help build any type of form or input. Look at the [form helper docs](https://edgeapi.rubyonrails.org/classes/ActionView/Helpers/FormHelper.html) for complete documentation.
 
-The entire form could look like:
+## A complete form
+After combining the `form_with` helper and some of the other view helpers mentioned above, by placing them in the block for `form_with`, we have the ERB code to generate a complete HTML form. The entire form could look like:
 
 ```erb
 <%= form_with url: "/books", method: :post do |f| %>
@@ -116,6 +117,22 @@ The entire form could look like:
 
   <%= f.submit "Save Book", class: "book-button" %>
 <% end %>
+```
+
+The above ERB code generates this HTML:
+
+```html
+<form action="/books" accept-charset="UTF-8" data-remote="true" method="post">
+  <p>Please provide the following information to save your book to our database:</p>
+
+  <label for="title">Title</label>
+  <input type="text" name="title" id="title" />
+
+  <label for="author">Author</label>
+  <input type="text" name="author" id="author" />
+
+  <input type="submit" name="commit" value="Save Book" class="book-button" data-disable-with="Save Book" />
+</form>
 ```
 
 ## Binding `form_with` to an ActiveRecord Model

--- a/08-rails/rails-forms.md
+++ b/08-rails/rails-forms.md
@@ -2,7 +2,7 @@
 We've [previously seen](../05-html-css/html-forms.md) how HTML forms can be used to submit information to websites, and have practiced creating them by manually. In this resource we will see that Rails has support for generating custom HTML forms that work well with Rails' conventions for models, controllers, and routes.
 
 ## Learning Goals
-- Learn how to generate a form in Rails with the `form_with` method.
+- Learn how to generate a form in Rails with the `form_with` method
 - Discover some useful _view helpers_ specifically for working with forms
 - Get a feel for handling form data in a _controller_
 

--- a/08-rails/rails-forms.md
+++ b/08-rails/rails-forms.md
@@ -8,7 +8,7 @@ We've [previously seen](../05-html-css/html-forms.md) how HTML forms can be used
 - Get a feel for handling form data in a _controller_
 
 ## The `form_with` view helper
-Similar to how `link_to` generates an achor tag, Rails has a method to generate a form named `form_with`. On the surface, they are very similar. Both are _view helpers_ that generate HTML content, and `form_with` is used to create a form, and can tie content to a specific type of model.
+Similar to how `link_to` generates an achor tag, Rails has a method to generate a form named `form_with`. On the surface, they are very similar. Both are _view helpers_ that generate HTML content, and `form_with` is used to create a form, and can tie content to a specific ActiveRecord model.
 
 `form_with` generates an HTML `<form>` element.  Below is one example specifying the URL to submit the form to and the HTTP method (verb) to use in the request.
 
@@ -179,10 +179,10 @@ end
 
 ## Note on `form_tag` and `form_for`
 
-Prior to Rails 5.1 Rails had two methods to generate forms in ERB.
+Prior to Rails 5.1 Rails had two methods to generate forms in ERB:
 
--   `form_tag` generates a generic HTML form not tied to a specific model.
--   `form_for` generates an HTML form tied to a specific model-type.
+-   `form_tag` generates a generic HTML form *not* tied to a specific model
+-   `form_for` generates an HTML form tied to a specific model
 
 You will see a lot of documentation, even in the [Rails Guide](http://guides.rubyonrails.org/form_helpers.html) for both `form_tag` and `form_for` and much less documentation for `form_with`.  All will still work, but the earlier methods are being soft-depreciated and will be replaced by `form_with` over time.  In particular, all the view helpers for the `form_for` method **will work** with the newer `form_with`.
 

--- a/08-rails/rails-forms.md
+++ b/08-rails/rails-forms.md
@@ -4,6 +4,7 @@ We've [previously seen](../05-html-css/html-forms.md) how HTML forms can be used
 ## Learning Goals
 - Learn how to generate a form in Rails with the `form_with` method
 - Discover some useful _view helpers_ specifically for working with forms
+- Learn the benefits that `form_with` has when using an ActiveRecord model
 - Get a feel for handling form data in a _controller_
 
 ## `form_with`

--- a/08-rails/rails-forms.md
+++ b/08-rails/rails-forms.md
@@ -211,9 +211,9 @@ If we submitted the `form_for` example above, the params hash would arrive in ou
 
 ```ruby
   {
-    "book" => {
-      "author" => "J.K. Rowling",
-      "title" => "Harry Potter and The Chamber of Secrets"
+    book: {
+      author: "J.K. Rowling",
+      title: "Harry Potter and The Chamber of Secrets"
     }
   }
 ```

--- a/09-intermediate-rails/view-helpers.md
+++ b/09-intermediate-rails/view-helpers.md
@@ -7,7 +7,7 @@ After Reading this you should be able to:
 - Understand what sorts of problems view helpers are good at solving.
 
 ## View Helpers
-We've already seen several built-in view helpers - things like `link_to`, `button_to`, and `form_for`. Rails also allows you to define your own custom view helpers. Custom helpers should be used for similar purposes: generating small amounts of HTML or text to be inserted into a web page.
+We've already seen several built-in view helpers - things like `link_to`, `button_to`, and `form_with`. Rails also allows you to define your own custom view helpers. Custom helpers should be used for similar purposes: generating small amounts of HTML or text to be inserted into a web page.
 
 New helper methods are defined in within the `app/helpers` directory. All of the helper files within `app/helpers` will be available to any page, the only reason to have separate files is to separate concerns. The `application_helper.rb` is a great place to define methods that are not specific to a model.
 


### PR DESCRIPTION
## Description
This started off with some review comments and turned into a much more substantial modification.

The overall impact of the changes is to introduce Rails forms more slowly, and to simplify earlier examples a bit.

I also made a choice to briefly mention the hidden input tags generated by Rails, and then leave them out of further code samples in order to minimize distractions.

## Additional changes required
I would highly suggest splitting this into two resources now, by splitting out all of the ActiveRecord related content.
