### PR TITLE
Change default git editor to nano

### DIFF
--- a/00-programming-fundamentals/installfest.md
+++ b/00-programming-fundamentals/installfest.md
@@ -99,6 +99,7 @@ $ git config --global core.ignorecase false
 $ git config --global color.diff auto
 $ git config --global color.status auto
 $ git config --global color.branch auto
+$ git config --global core.editor "nano"
 ```
 
 ### Trust but Verify


### PR DESCRIPTION
## Description
A suggestion to make the installfest default editor for git as nano.  At least you can read how to exit the editor on the screen.

If you don't think we should do this, just reject the PR.