### PR TITLE
Make view helper info on named paths consistent with other resources

### DIFF
--- a/08-rails/common-view-helpers.md
+++ b/08-rails/common-view-helpers.md
@@ -33,6 +33,29 @@ The above `link_to` will give you this HTML:
 <a href="/profile" class="link">About Me</a>
 ```
 
+#### Named Paths
+
+In addition to regular strings, `link_to` can (and should) use the generated helper methods for named paths. For example, to link to the list of books:
+
+```erb
+<%= link_to "Book List", books_path %>
+```
+
+generates
+
+```html
+<a href="/books">Book List</a>
+```
+
+If you wanted to provide a link to each of the books stored in the array `@books`, you might write
+
+```erb
+@books.each do |book|
+  <%= link_to book.title, book_path(book) %>
+end
+```
+
+
 ### `image_tag(filename, options)`
 `image_tag` generates an HTML `<img>` tag. The argument given will be an image filename for the `src` attribute. Rails (the asset pipeline) looks in the `app/assets/images` directory for images. You can provide additional attributes as optional hash parameters:
 
@@ -45,65 +68,6 @@ The above `image_tag` will give you this HTML:
 ```html
 <img src="/assets/cat.jpg" alt="The cutest cat in the whole world.">
 ```
-
-## Using Named Routes
-
-Above we used hard-coded paths like "/profile" in our helpers.  We can also use methods like `link_to` with named routes from our `config/routes.rb` file.  
-
-For example:
-
-```erb
-<%= link_to "All Books", books_path %>
-```
-
-Can function as a link to the `books#index` action.  Rails automatically provides a helper for each path.  The name of each helper is the name of the path with `_path` on the end. 
-
-Named routes are helpful because if we want to change the path we then only have to edit `config/routes.rb` once and the helper methods will then use the new path.
-
-So for a `routes.rb` file like:
-
-```ruby
-# config/routes.rb
-Rails.application.routes.draw do
-
-  root "books#index"
-
-  get "/books/new", to: "books#new", as: "new_book"
-  post "/books", to: "books#create", as: "books"
-
-  get '/books/:id/edit', to: 'books#edit', as: "edit_book"
-  patch '/books/:id', to: 'books#update'
-
-  get "/books", to: "books#index"
-  get "/books/:id", to: "books#show", as: "book"
-
-  delete "/books/:id", to: "books#destroy", as: "delete_book"
-end
-```
-
-Will result in the following helpers:  
--  `books_path`
--  `new_book_path`
--  `edit_book_path`
--  `book_path`
--  `delete_book_path`
-
-Rails will only generate route helper methods for each *named* path.
-
-### Paths with Parameters
-
-Some paths like to the `books#show` action require a parameter.  
-
-```erb
-<%= link_to "Book #4", book_path(4) %>
-```
-
-The sample above would provide a link for a book with ID number 4.
-
-```html
-<a href="/books/4">Book #4</a>
-```
-
 
 ## Helpful Links
 - [An overview of helpers](http://guides.rubyonrails.org/action_view_overview.html#overview-of-helpers-provided-by-action-view)


### PR DESCRIPTION
## Description
The goal was to reduce redundancy with the lessons on [route parameters](https://github.com/Ada-Developers-Academy/textbook-curriculum/blob/master/08-rails/route-parameters.md) and [restful routing](https://github.com/Ada-Developers-Academy/textbook-curriculum/blob/master/08-rails/restful-routing.md), which cover the same material in deeper detail earlier in the week.

## Questions for the Author
- [N/A] Have you updated the weekly learning goals in the pedagogy resource?
- [N/A] Have you updated the weekly assessment in Schoology?
- [N/A] Have you added links to the source (lucidchart, draw.io) for any diagram?
- [N/A] Have you updated the READMEs with links to new or moved resources?

## Todos
None

## Feedback Requested
Nothing special