### PR TITLE
Update linters to allow ES6 additions like `Set`.

### DIFF
--- a/10-JavaScript/exercises/setup-linting.md
+++ b/10-JavaScript/exercises/setup-linting.md
@@ -61,7 +61,8 @@ Add this file `~/.eslintrc`
     "browser": true,
     "commonjs": true,
     "jquery": true,
-    "jest/globals": true
+    "jest/globals": true,
+    "es6": true
   }
 }
 ```


### PR DESCRIPTION
Small addition to the linter set up to allow ES6 data structures like `Set`.  