### PR TITLE
Update to no-document gem tag

### DIFF
--- a/08-rails/installfest-rails.md
+++ b/08-rails/installfest-rails.md
@@ -22,7 +22,7 @@ The web applications we write will begin to use a [_database_](https://en.wikipe
 
 [Ruby on Rails](https://en.wikipedia.org/wiki/Ruby_on_Rails) is distributed as a gem!
 
-1. In any directory, run `$ gem install rails --no-rdoc --no-ri`
+1. In any directory, run `$ gem install rails --no-document`
 1. Verify that it gives a success message
 
 ## Related Topics


### PR DESCRIPTION
The tags --no-rdoc and --no-ri have been merged into new tag --no-document. See https://gitlab.com/gitlab-org/gitlab-ce/issues/55740

## Description
A few sentences describing the overall purpose of these textbook changes.

## Questions for the Author
**N/A**
- [ ] Have you updated the weekly learning goals in the pedagogy resource?
- [ ] Have you updated the weekly assessment in Schoology?
- [ ] Have you added links to the source (lucidchart, draw.io) for any diagram?
- [ ] Have you updated the READMEs with links to new or moved resources?

## Todos
Are any of these items still in progress? **No**
- [ ] Section X still needs some more detailed examples
- [ ] Still need to add "Additional Resources"

## Feedback Requested
Please utilize the built-in GitHub Reviewers functionality to assign necessary reviewers. Use this section to further specify portions of the PR that you would like additional or focused feedback on.
