### PR TITLE
Remove gist links to my personal GitHub account

### DIFF
--- a/01-ruby-fundamentals/exercises/friendship-note.md
+++ b/01-ruby-fundamentals/exercises/friendship-note.md
@@ -114,7 +114,7 @@ puts "Thank you for using the friendship note app"
 
 When we run the code `print_note(user_name, friend_name)`, we _invoke_ the method we _defined_ above, passing in two _arguments_ to match the _parameters_ in the _method signature_.
 
-[The final version of the file should look like this.](https://gist.github.com/droberts-ada/4dd96ed4122081bf0aa673352230f458) Now we can run the whole thing from the terminal (not `irb`) using `ruby friendship_note.rb`.
+[The final version of the file should look like this.](source/friendship-note.rb) Now we can run the whole thing from the terminal (not `irb`) using `ruby friendship_note.rb`.
 
 ## Diagram
 

--- a/01-ruby-fundamentals/exercises/object-vocabulary.md
+++ b/01-ruby-fundamentals/exercises/object-vocabulary.md
@@ -9,7 +9,7 @@
 
 The below code might be part of a library database, tracking which books have been loaned out to which patrons.
 
-This code is in an image so that we can highlight specific parts of it. [If you want a text version, use this gist](https://gist.github.com/droberts-ada/e1924d86244328102e98c835cc3e2aea). To see the full resolution version, click the image and then click `Download`.
+This code is in an image so that we can highlight specific parts of it. [You can find a text version here](source/object-vocabulary). To see the full resolution version, click the image and then click `Download`.
 
 ![Library Code](../images/object_vocab_worksheet.png)
 <!-- Instructors: source for this image is at https://docs.google.com/presentation/d/1Ro-4od5VZLV7NR_T8uvg5wZZlxl6WtilH6sWXTcl8cI/edit#slide=id.p -->

--- a/01-ruby-fundamentals/exercises/source/friendship-note.rb
+++ b/01-ruby-fundamentals/exercises/source/friendship-note.rb
@@ -1,0 +1,36 @@
+# friendship_note.rb
+def print_heart
+  puts "   .:::.   .:::.    "
+  puts "  :::::::.:::::::   "
+  puts "  :::::::::::::::   "
+  puts "  ':::::::::::::'   "
+  puts "    ':::::::::'     "
+  puts "      ':::::'       "
+  puts "        ':'         "
+end
+
+def print_note(sender_name, receiver_name)
+  puts "Dear #{receiver_name},"
+  print_heart
+
+  puts "You are a good friend to me,"
+  print_heart
+
+  puts "And I hope you have a wonderful day!"
+  print_heart
+
+  puts "Sincerely, #{sender_name}"
+end
+
+puts "Welcome to the friendship note app"
+
+puts "What is your name?"
+user_name = gets.chomp
+
+puts "Who is your friend?"
+friend_name = gets.chomp
+
+puts "OK, here is your note"
+print_note(user_name, friend_name)
+
+puts "Thank you for using the friendship note app"

--- a/01-ruby-fundamentals/exercises/source/object-vocabulary/loan.rb
+++ b/01-ruby-fundamentals/exercises/source/object-vocabulary/loan.rb
@@ -1,0 +1,29 @@
+require "date"
+
+class Loan
+  attr_reader :title, :check_out_date, :due_date, :check_in_date
+
+  def initialize(title)
+    @title = title
+    @check_out_date = Date.today
+
+    # Books are due 4 weeks from check out date
+    @due_date = Date.today + (4 * 7)
+
+    # For loans that haven't been checked in check_in_date is nil.
+    # Instance variables that haven't been initialized have
+    # a default value of nil, so we don't need the next line
+    # check_in_date = nil
+  end
+
+  def check_in
+    @check_in_date = Date.today
+  end
+
+  def overdue?
+    # For a book to be overdue, two things must be true:
+    # - The current date must be later than the loan's due date
+    # - The book must not be checked in (check_in_date is nil)
+    return @due_date < Date.today && @check_in_date.nil?
+  end
+end

--- a/01-ruby-fundamentals/exercises/source/object-vocabulary/patron.rb
+++ b/01-ruby-fundamentals/exercises/source/object-vocabulary/patron.rb
@@ -1,0 +1,35 @@
+require_relative "loan"
+
+class Patron
+  attr_reader :first_name, :last_name, :email, :loans
+
+  def initialize(first_name, last_name, email)
+    @first_name = first_name
+    @last_name = last_name
+    @email = email
+    @loans = []
+  end
+
+  def overdue_books
+    overdues = []
+    @loans.each do |loan|
+      if loan.overdue?
+        overdues << loan
+      end
+    end
+    return overdues
+  end
+
+  def check_out(title)
+    loan = Loan.new(title)
+    @loans << loan
+  end
+
+  def check_in(title)
+    @loans.each do |loan|
+      if loan.title == title
+        loan.check_in
+      end
+    end
+  end
+end

--- a/02-intermediate-ruby/class-methods-and-self.md
+++ b/02-intermediate-ruby/class-methods-and-self.md
@@ -346,7 +346,7 @@ For example, what if we wanted a method that, given an array of `Song`s, picks t
 
 Work with a partner to implement `Song.most_played`. As you write the method, think about how you would test it - what interesting scenarios can you imagine?
 
-Once you've come up with an version you're happy with, [you can see ours here](https://gist.github.com/droberts-ada/8f3e70aa8dd05450f8c8b41692e206fc).
+Once you've come up with an version you're happy with, [you can see ours here](source/song.rb).
 
 ## Conclusion
 

--- a/02-intermediate-ruby/source/song.rb
+++ b/02-intermediate-ruby/source/song.rb
@@ -1,0 +1,59 @@
+# Finished code for the "Class Methods and Self" lesson
+
+class Song
+  attr_reader :title, :artist, :filename, :play_count
+
+  # Initialize our total play count
+  # This will be set to 0 when the program is loaded
+  @@total_plays = 0
+
+  def initialize(title, artist, filename)
+    @title = title
+    @artist = artist
+    @filename = filename
+    @play_count = 0
+  end
+
+  def summary
+    return "#{@title}, by #{@artist}"
+  end
+
+  def play
+    @play_count += 1
+    @@total_plays += 1
+    # ... load the song data from the file and send it to the speakers ...
+  end
+
+  def self.total_plays
+    return @@total_plays
+  end
+
+  def self.most_played(song_list)
+    most_played = song_list[0]
+    song_list.each do |song|
+      if song.play_count > most_played.play_count
+        most_played = song
+      end
+    end
+    return most_played
+  end
+end
+
+s1 = Song.new("Respect", "Aretha Franklin", "songs/respect.mp3")
+s2 = Song.new("What a Little Moonlight Can Do", "Billie Holiday", "songs/moonlight.mp3")
+s3 = Song.new("Adore", "Savages", "songs/adore.mp3")
+
+3.times do
+  s1.play
+end
+
+5.times do
+  s2.play
+end
+
+2.times do
+  s3.play
+end
+
+top_song = Song.most_played([s1, s2, s3])
+puts top_song.summary

--- a/02-intermediate-ruby/testing-with-minitest.md
+++ b/02-intermediate-ruby/testing-with-minitest.md
@@ -259,7 +259,15 @@ You may remember from the [Introduction to Automated Testing](../00-programming-
 1. The seconds are greater than or equal to 60, should raise an error
 1. Any parameter is less than 0, should raise an error
 
-**Question** Are there other edge-cases we should test for?  Do any other inputs cause different behaviors in the method?  Talk about it with your SeatSquad members.  If you are unsure check [here](https://gist.github.com/ada-instructor-1/27c2cb78b177a6139241860a6bc54712).
+<details>
+<summary>
+<b>Question:</b> Are there other edge-cases we should test for?  Do any other inputs cause different behaviors in the method?  Talk about it with your SeatSquad members, and click here for an answer if you are still unsure.
+</summary>
+
+- You should also test numbers less than 10
+- Numbers smaller than 10 should include a leading zero
+
+</details>
 
 We will choose to ignore for now cases where the user passes a non-integer in as a parameter.  In that case it should cause a runtime error.
 


### PR DESCRIPTION
## Description
Exactly what it says on the tin. I did double check that all links go to the right place.

There are a number of gist links still in the Backbone section, but that's deprecated anyway so I figured it's not worth the trouble.

## Questions for the Author
- [ ] N/A Have you updated the weekly learning goals in the pedagogy resource?
- [ ] N/A Have you updated the weekly assessment in Schoology?
- [ ] N/A Have you added links to the source (lucidchart, draw.io) for any diagram?
- [ ] N/A Have you updated the READMEs with links to new or moved resources?

## Todos
None

## Feedback Requested
Nothing special