### PR TITLE
Fixed code sample for TreeNode class in Binary Tree exercises

### DIFF
--- a/04-cs-fundamentals/internship/exercises/binary-tree.md
+++ b/04-cs-fundamentals/internship/exercises/binary-tree.md
@@ -30,10 +30,10 @@ class TreeNode
   attr_accessor :left, :right
 
   def initialize(key, value, left = nil, right = nil)
-    @key = k
-    @value = v
-    @left = l
-    @right = r
+    @key = key
+    @value = value
+    @left = left
+    @right = right
   end
 end
 ```


### PR DESCRIPTION
## Description
The code sample provided in the Binary Tree exercises had a bug in which the variable names used in the `initialize` method of the `TreeNode` class did not match the parameter names in the method signature.