### PR TITLE
change user properties to be named consistently with implementing oauth activity

### DIFF
--- a/09-intermediate-rails/testing-oauth.md
+++ b/09-intermediate-rails/testing-oauth.md
@@ -61,16 +61,16 @@ These test fixtures are very similar to those we've made in the past. The only d
 
 ```yml
 ada:
-  oauth_provider: github
-  oauth_uid: 12345
+  provider: github
+  uid: 12345
   email: ada@adadevelopersacademy.org
-  username: countess_ada
+  name: countess_ada
 
 grace:
-  oauth_provider: github
-  oauth_uid: 13371337
+  provider: github
+  uid: 13371337
   email: grace@hooper.net
-  username: graceful_hopps
+  name: graceful_hopps
 ```
 
 #### Logging In
@@ -96,11 +96,11 @@ class ActiveSupport::TestCase
   # for fixture data
   def mock_auth_hash(user)
     return {
-      provider: user.oauth_provider,
-      uid: user.oauth_uid,
+      provider: user.provider,
+      uid: user.uid,
       info: {
         email: user.email,
-        nickname: user.username
+        nickname: user.name
       }
     }
   end
@@ -163,7 +163,7 @@ Note that we do check `session[:user_id]` here. Rails controller tests do let us
 ```ruby
 it "creates a new user" do
   start_count = User.count
-  user = User.new(oauth_provider: "github", oauth_uid: 99999, username: "test_user", email: "test@user.com")
+  user = User.new(provider: "github", uid: 99999, name: "test_user", email: "test@user.com")
 
   OmniAuth.config.mock_auth[:github] = OmniAuth::AuthHash.new(mock_auth_hash(user))
   get auth_callback_path(:github)


### PR DESCRIPTION
Going over this lesson, there were a lot of clashes with [this previous activity](https://github.com/Ada-Developers-Academy/textbook-curriculum/blob/master/09-intermediate-rails/oauth.md)

These changes make them consistent. I haven't looked into future lessons to see if they conflict with this at all.