### PR TITLE
Remove the CSRF file update

### DIFF
--- a/09-intermediate-rails/api-creating-items.md
+++ b/09-intermediate-rails/api-creating-items.md
@@ -62,14 +62,7 @@ As before, the big difference from a web app is in what we send back. While in a
 
 **ALERT!** Rails is built with CSRF protection which essentially prevents malicious requests. You might remember seeing notes in passing about this in our forms curriculum, where we had to explicitly add an _authenticity token_ to each form.
 
-Since we expect requests to come from other sites/applications in an API context, we will add a Rails helper method to our controller to allow these `POST` requests to go through:
-```ruby
-# pets_controller.rb
-class PetsController < ApplicationController
-  protect_from_forgery with: :null_session
-
-  ...
-```
+We don't this in an API application, although we might need to modify our code if we wrote an application which could serve both API and browser requests.
 
 You can [read more about CSRF](http://guides.rubyonrails.org/security.html#cross-site-request-forgery-csrf) in the Rails documentation.
 

--- a/09-intermediate-rails/api-creating-items.md
+++ b/09-intermediate-rails/api-creating-items.md
@@ -62,7 +62,7 @@ As before, the big difference from a web app is in what we send back. While in a
 
 **ALERT!** Rails is built with CSRF protection which essentially prevents malicious requests. You might remember seeing notes in passing about this in our forms curriculum, where we had to explicitly add an _authenticity token_ to each form.
 
-We don't this in an API application, although we might need to modify our code if we wrote an application which could serve both API and browser requests.
+If we don't do this in an API application, we might need to modify our code if we wanted to serve both API (JSON) and browser requests (HTML).
 
 You can [read more about CSRF](http://guides.rubyonrails.org/security.html#cross-site-request-forgery-csrf) in the Rails documentation.
 


### PR DESCRIPTION
## Description

I just discovered that we'd had a line in our Post request lesson that no longer applies to current versions of Rails 5 or 6.  So I'm taking it out and making a note that you'd have to do something different if you had an App which served both HTML and JSON.

