### PR TITLE
React testing to React Testing Library

### DIFF
--- a/React/testing.md
+++ b/React/testing.md
@@ -306,15 +306,15 @@ Write another, very similar, test to verify that the other button also calls the
 ## Summary
 
 - Jest is included with React by default
-- Enzyme is a library that provides more convenient testing syntax, as well as some advanced functionality
+- The React Testing Library is a library that provides more convenient testing syntax, as well as some advanced functionality.
+  - This advanced functionality includes:
+    - Rendering components for testing
+    - Selecting elements in a rendered component.
+    - Verifying that components contain specific content
+    - Verifying that callback functions are called
 - Snapshot testing allows you to detect when your component changes
-- Enzyme has two methods for rendering components: `shallow` and `mount`
-  - `shallow` renders only the component you specify, and should be the default choice
-  - `mount` renders a component and all its children, and should be used only when you need to test cross-component interactions
 
 ## Resources
-- [Tutorial on Testing React](https://medium.com/tribalscale/tutorial-on-testing-react-part-1-2c587e39114d)
-- [The Right way to test React Components](https://medium.freecodecamp.org/the-right-way-to-test-react-components-548a4736ab22)
-- [Jest Documentation - Testing React Apps](https://facebook.github.io/jest/docs/en/tutorial-react.html)
-- [Using Jest with enzyme](https://github.com/airbnb/enzyme/blob/master/docs/guides/jest.md)
+
+- [React Testing Library Documentation](https://testing-library.com/docs/react-testing-library/intro)
 - [FreeCodeCamp React Testing with Jest](https://medium.com/p/b71c27b0a795#54c3)

--- a/React/testing.md
+++ b/React/testing.md
@@ -14,18 +14,19 @@ By the end of this lesson you should be able to:
 
 In this lesson we will be learning testing through the React pets project we worked on earlier.
 
-You can clone [our implementation of the ada-pets project](https://github.com/AdaGold/react-pets), and switch to the `solution` branch, if needed.
+You can clone [our implementation of the ada-pets project](https://github.com/AdaGold/ada-pets-react), and switch to the `solution` branch, if needed.
 
-Once you have cloned the repository remember to run `npm install` to install the project dependencies.
+Once you have cloned the repository remember to run `yarn` to install the project dependencies, and to verify it with `yarn start` to start the application.
 
-### Installing Enzyme & React Test Renderer
+### Installing the React Testing Library
 
-Enzyme is a handy library which will make it easier to manipulate, traverse and make assertions on our React components.  It's made to work similar to jQuery for selecting, rendering and manipulating the DOM.
+We will use the [React Testing Library](https://testing-library.com/docs/react-testing-library/intro), which is part of a larger testing framework for JavaScript called, creatively, [Testing Library](https://testing-library.com/).  This is a testing library that tries to simulate how end-users see the React App.  It is a library which is growing in popularity with the React and larger JavaScript community.
 
-To install enzyme for testing your application, execute from the terminal:
+You can install it with `brew` &  `yarn`:
 
 ```bash
-npm i --save-dev enzyme enzyme-adapter-react-16 enzyme-to-json
+$ brew install watchman
+$ yarn add @testing-library/react @testing-library/jest-dom
 ```
 
 **Note** This will install enzyme and an adapter or version 16 of React.  You can expect a new adapter for later versions of React.

--- a/React/testing.md
+++ b/React/testing.md
@@ -29,28 +29,6 @@ $ brew install watchman
 $ yarn add @testing-library/react @testing-library/jest-dom
 ```
 
-**Note** This will install enzyme and an adapter or version 16 of React.  You can expect a new adapter for later versions of React.
-
-Next we need to tell Jest how to serialize enzyme data. Open up `package.json` and add the following object:
-
-```json
-"jest": {
-  "snapshotSerializers": ["enzyme-to-json/serializer"]
-}
-```
-
-Finally, tell Jest how to configure enzyme and use the adapter.  Create the file `src/setupTests.js` and add the following content.
-
-```javascript
-// src/setupTests.js
-import { configure } from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
-
-configure({ adapter: new Adapter() });
-```
-
-This file is run when you start testing with create-react-app and allows us to tell enzyme which adapter to use.  If you have tests running you will need to exit and restart Jest.
-
 **You will need to follow these steps for every new React project you create.**
 
 ### Test Files

--- a/React/testing.md
+++ b/React/testing.md
@@ -202,6 +202,8 @@ You may wonder, "Where are these snapshots saved?"  You can see the snapshot fil
 
 Notice that the snapshot file looks a lot like the JSX rendered by the component, but it's a generated text file making it easier to compare to new snapshots.  You generally won't need to look at these files directly, but looking at the snapshot file should help you understand how Jest compares the current snapshot to the rendered content from the test.  It can also help you understand how a component is being rendered into HTML.  You should commit these files to git, so that other developers can use your snapshots in their testing.
 
+This is kind of like the VCR cassette files you created when consuming APIs in Ruby.  VCR recorded the API recorded the API interactions into text files and could then replay them on demand.
+
 ### The Downside of Snapshot Testing
 
 Snapshot testing has a few disadvantages.  First, small changes to a component can often cause them to fail, and because it's very easy to update a snapshot without looking closely, it's easy to miss scenarios where they report a serious bug.  Essentially they give a lot of false, failures and so get discounted.  Think of [the little boy who cried wolf](http://www.storyarts.org/library/aesops/stories/boy.html).

--- a/React/testing.md
+++ b/React/testing.md
@@ -3,9 +3,12 @@
 Here we will try to ensure that individual components work predictably by testing for unexpected changes to UI and how users interact with our components.  We will introduce two forms of testing unlike any we have done with Ruby, Snapshot testing & testing user interfaces.
 
 ## Learning Goals
+
 By the end of this lesson you should be able to:
+
 - Explain the terms _Snapshot Test_, and _shallow_ and _deep_ rendering
 - Write tests to verify components exist and have not changed
+- Write tests to verify callback functions are called on the correct events
 
 ## Getting Started
 

--- a/React/testing.md
+++ b/React/testing.md
@@ -201,41 +201,60 @@ Snapshot testing has a few disadvantages.  First, small changes to a component c
 
 That said, they can be very quick to write and useful for unit-testing functional components which you do not expect to change much.  They can also give you a clearer picture of the rendered html a component results in.
 
+## Selecting and Testing Rendered Content
+
+Often we want to ensure specific content is rendered in a React component.  We want to find a specific element and verify that the content is set properly.  Maybe that it has the proper class, or that the text inside an element is correct.  Our testing library has a number of selectors we can use to find elements in our rendered component.  Each of these selectors will return an HTML Element object.
+
+### Queries
+
+| Method Name | Example | What it does |
+|--- |--- |--- |
+| getByLabelText | `getBy(container, 'Name')` | Searches for the label which matches the given text  and returns the element associated with the given label.  In `NetPetForm` this would be the input associated with the "Name" label. |
+| getByPlaceholderText | `getByPlaceholderText(container, 'password')` | Searches for the first element with a placeholder element equal to the given value. |
+| getByText | `getByText(container, /Select/i)` | Searches for the first element with text content matching the string or regular expression given. |
+| getByAltText | `getByAltText(container, 'kitty pic')` | Searches for the first element with an `alt` attribute equal to the given string or regex. |
+| getByTitle | `getByTitle(container, /Select/i)` | Searches for the first element with a `title` attribute like `<span title="Select" id="2"></span>` equal to the given value. |
+| getByDisplayValue | `getByDisplayValue(container, /Ada/)` | Searches for the first `input`, `select` or `textarea` with the given display value.|
+| getByRole | `getByRole(container, 'dialog')` | Searches for the first element with a `role` attribute equal to the given value like: `<div role="dialog"></div>` |
+| ByTestId | `getByTestId(container, 'name-input')` | Searches for an HTML element with a `data-testid` attribute equal to the given value such as `<input name="name" id="name" data-testid="name-input" />` |
+
+There are also other variations of the above query methods which can select all matching elements and can either return an empty array or raise an error if no matches are found.  
+
+For our `PetCard` component we could write a test to verify that the Pet name is displayed properly.
+
 ```javascript
-// src/App.test.js
-import React from 'react';
-import ReactDOM from 'react-dom';
-import { mount, shallow } from 'enzyme';
-import App from './App';
+  // src/components/test/PetCard.test.js
+  test('It will render the proper name for the pet', () => {
+    const container = render(<PetCard
+      id={1}
+      name={"Samson"}
+      species={"Cat"}
+      about={"A very awesome cat!  Don't touch the hair!"}
+      location={"Seattle, WA"}
+      deletePetCallback={() => { }}
+      selectPetCallback={() => { }}
+    />);
 
-describe('<App />', () => {  
-  test('that it renders App with shallow rendering', () => {
-    const wrapper = shallow(<App />);
-    expect(wrapper).toMatchSnapshot();
+    expect(container.getByText(/Samson/)).toBeDefined();
   });
-
-  test('will match the last snapshot with deep rendering', () => {
-    const wrapper = mount(<App />);
-    expect(wrapper).toMatchSnapshot();
-
-    // Remove the component from the DOM (save memory and prevent side effects).
-    wrapper.unmount();
-  });
-});
 ```
 
-**Question** Run the above two tests.  What do you notice about the differences in the two Snapshots?
+This test above simply verifies that "Samson" appears somewhere in the rendered HTML.  We could be more specific with our selector if we want to ensure that the element with this text has specific values or attributes.  
 
-The `mount` function fully mounts a component and all subcomponents in the DOM. This makes the test more fragile, but also more powerful.
+**Exercise**
 
-Notice also that we call `wrapper.unmount()` at the end of our deep snapshot test. This is because `mount` modifies some global variables in the test environment, and we need to undo this work to avoid side effects and make our tests independent from one another. **Whenever you write a deep snapshot test with `.mount`, you _must_ include a corresponding `.unmount`.**
+Use `console.log` to output the result of: `container.getByText(/Seattle, WA/))`.  What does this give you when you run the tests?  What methods are available.  You can use VS Code's intellisense to put a period after `container.getByText(/Seattle, WA/)` and get a list of the attributes and methods available to that HTML Element.
 
-Use `mount` when you need to test the interaction between a container and child component.  Otherwise for unit testing use `shallow` almost exclusively.  You should **avoid** using `mount` for snapshot testing unless you need it.
+<details>
+  <summary>Try to write a test to verify that the tag enclosing the pet's location must have the className "pet-card--footer".</summary>
 
-| Enzyme Function | Used for |  Description |
-| ------ | ------ | ----- |
-|  mount  |  Deep Rendering | Renders the entire component and subcomponent to test their interactions  |
-|  shallow  |  shallow rendering  | Used for tests on a single component in isolation.
+  You can do so with:  
+  ```javascript
+  expect(container.getByText(/Seattle, WA/).classList).toContain('pet-card--footer');
+  ```
+</details>
+
+So far we have only used the `getByText` function, but we could use any of the earlier queries to find elements in our rendered component.  For example we could add an attribute called `data-testid` to a button in the React component and then select that element using our testing library's `getByTestId` query function.
 
 ## Event Handling
 

--- a/React/testing.md
+++ b/React/testing.md
@@ -103,6 +103,8 @@ The default test in `App.test.js` first creates a `div` element which is **not**
 
 This test doesn't actually make any assertions, there are no `expect(div).toBe(y)` commands, but it ensures that the component will show up on the screen without crashing React.
 
+All of this uses the built-in React & Jest libraries to test the application.  Next we will use the React Testing Library to render components and verify that they behave as expected.
+
 ## Snapshot Testing
 
 ### What is it?

--- a/React/testing.md
+++ b/React/testing.md
@@ -231,6 +231,7 @@ For our `PetCard` component we could write a test to verify that the Pet name is
   // ... Other tests and imports
 
   test('It will render the proper name for the pet', () => {
+    // Arrange & Act
     const container = render(<PetCard
       id={1}
       name={"Samson"}
@@ -241,6 +242,7 @@ For our `PetCard` component we could write a test to verify that the Pet name is
       selectPetCallback={() => { }}
     />);
 
+    // Assert
     expect(container.getByText(/Samson/)).toBeDefined();
   });
 ```

--- a/React/testing.md
+++ b/React/testing.md
@@ -22,14 +22,19 @@ Once you have cloned the repository remember to run `yarn` to install the projec
 
 We will use the [React Testing Library](https://testing-library.com/docs/react-testing-library/intro), which is part of a larger testing framework for JavaScript called, creatively, [Testing Library](https://testing-library.com/).  This is a testing library that tries to simulate how end-users see the React App.  It is a library which is growing in popularity with the React and larger JavaScript community.
 
-You can install it with `brew` &  `yarn`:
+To run tests in React in guard-mode we'll need to first install watchman with `brew`.
 
 ```bash
 $ brew install watchman
+```
+
+Then you can install the testing library with  `yarn`:
+
+```bash
 $ yarn add @testing-library/react @testing-library/jest-dom
 ```
 
-**You will need to follow these steps for every new React project you create.**
+**You will need to install the testing library every new React project you create.**
 
 ### Test Files
 

--- a/React/testing.md
+++ b/React/testing.md
@@ -258,7 +258,50 @@ So far we have only used the `getByText` function, but we could use any of the e
 
 ## Event Handling
 
-Enzyme also allows you to write tests for user interaction, using a jQuery-like syntax to simulate events. We won't cover that in this class, but if that sounds interesting to you you can [read more about simulating events here](https://airbnb.io/enzyme/docs/api/ReactWrapper/simulate.html).
+We can also write a test to verify that the callback functions are called when a button is clicked.
+
+```javascript
+// src/components/test/PetCard.test.js
+test('The "selectPetCallback" function is called when the `select` button is clicked on', () => {
+
+    // Arrange
+    // Create a mock callback function
+    const selectPet = jest.fn();
+
+    // Render a PetCard
+    const container = render(<PetCard
+      id={1}
+      name={"Samson"}
+      species={"Cat"}
+      about={"A very awesome cat!  Dont' touch the hair"}
+      location={"Seattle, WA"}
+      deletePetCallback={() => { }}
+      selectPetCallback={selectPet}
+    />);
+
+    // Act
+    // Find the "Select" button
+    const selectButton = container.getByText(/Select/);
+    // Trigger a 'click' event
+    selectButton.click();
+
+    // Assert
+    // Verify that the callback function was called.
+    expect(selectPet).toHaveBeenCalled();
+  });
+```
+
+In the code above we:
+
+1. First created a mock, callback function called `selectPet` using Jest.  This is a function that Jest can create for us which will track the number of times it has been called.  
+   - You can read more about these in the [Jest Documentation](https://jestjs.io/docs/en/mock-functions). 
+2. Second rendered a new `PetCard` component and passed in the `selectPet` function as the `selectPetCallback` prop.
+3. Third Triggered a click event on the `select` button.
+4. Lastly verified that the callback function was called.
+
+**Exercise**
+
+Write another, very similar, test to verify that the other button also calls the `deletePetCallback` prop.
 
 ## Summary
 

--- a/React/testing.md
+++ b/React/testing.md
@@ -226,6 +226,10 @@ For our `PetCard` component we could write a test to verify that the Pet name is
 
 ```javascript
   // src/components/test/PetCard.test.js
+  import { render, cleanup } from '@testing-library/react'
+
+  // ... Other tests and imports
+
   test('It will render the proper name for the pet', () => {
     const container = render(<PetCard
       id={1}


### PR DESCRIPTION
## Description

This is a rework to move testing from Enzyme towards the [React Testing Library](https://testing-library.com/docs/react-testing-library/intro), which is gaining steam lately.  It also introduces simulating dom events and verifying that callback functions are called and de-emphasizes snapshot testing, which I think is not fantastically useful.

## Questions for the Author
- [x] Have you updated the weekly learning goals in the pedagogy resource?

## Todos

Are any of these items still in progress?
- [ ] I may want to redo the screenshots
- [ ] Still need to add "Additional Resources" with some of the many video tutorials

## Feedback Requested
Please utilize the built-in GitHub Reviewers functionality to assign necessary reviewers. Use this section to further specify portions of the PR that you would like additional or focused feedback on.
