### PR TITLE
first example: changed 8 hours to 11 hours

### DIFF
--- a/02-intermediate-ruby/testing-with-minitest.md
+++ b/02-intermediate-ruby/testing-with-minitest.md
@@ -217,7 +217,7 @@ Minitest::Reporters.use!
 describe "clock" do
   it "can be called with hours, minutes and seconds as arguments" do
     # Arrange
-    hours = 8
+    hours = 11
     minutes = 14
     seconds = 27
 
@@ -231,7 +231,7 @@ describe "clock" do
 
   it "will return a string formatted in hh:mm:ss format" do
     # Arrange
-    hours = 8
+    hours = 11
     minutes = 14
     seconds = 27
 
@@ -239,7 +239,7 @@ describe "clock" do
     time = clock(hours, minutes, seconds)
 
     # Assert
-    expect((time)).must_equal "08:14:27"
+    expect((time)).must_equal "11:14:27"
   end
 end
 ```


### PR DESCRIPTION
I changed the first test input from 8 hours to 11 hours, since we are initially not dealing with the issue of needing to prepend 0s. It seems make sense to have a simpler example and then note how this would change for single digit values.