### PR TITLE
fix typo in summary

### DIFF
--- a/01-ruby-fundamentals/raising-exceptions.md
+++ b/01-ruby-fundamentals/raising-exceptions.md
@@ -191,7 +191,7 @@ Just because a Warning doesn't stop your program from running doesn't mean we ca
 
 ## Summary
 
-In this lesson we have seen that an exception is a indication of a problem in your application.  When an exception occurs the method or block is immediately exited and ruby continues to retrace through the the call stack until the program ends and produces a _stack trace_ which lists the methods and line numbers which can help the programmer debug the application. We have also seen how we can raise our own `ArgumentError` Exceptions and how it can help prevent our methods from being called with invalid arguments.
+In this lesson we have seen that an exception is a indication of a problem in your application.  When an exception occurs the method or block is immediately exited and ruby continues to retrace through the call stack until the program ends and produces a _stack trace_ which lists the methods and line numbers which can help the programmer debug the application. We have also seen how we can raise our own `ArgumentError` Exceptions and how it can help prevent our methods from being called with invalid arguments.
 
 ## More Resources
 -   [RubyLearning.com on Exceptions](http://rubylearning.com/satishtalim/ruby_exceptions.html)


### PR DESCRIPTION
## Description
Removed duplicate "the" in the second sentence of the summary portion.

## Questions for the Author
- [ ] Have you updated the weekly learning goals in the pedagogy resource?
- [ ] Have you updated the weekly assessment in Schoology?
- [ ] Have you added links to the source (lucidchart, draw.io) for any diagram?
- [ ] Have you updated the READMEs with links to new or moved resources?

## Todos
Are any of these items still in progress?
- [ ] Section X still needs some more detailed examples
- [ ] Still need to add "Additional Resources"

## Feedback Requested
Please utilize the built-in GitHub Reviewers functionality to assign necessary reviewers. Use this section to further specify portions of the PR that you would like additional or focused feedback on.
