### PR TITLE
Issue I encountered with install

### DIFF
--- a/02-intermediate-ruby/testing-with-guard.md
+++ b/02-intermediate-ruby/testing-with-guard.md
@@ -19,6 +19,8 @@ Before we can use Guard to automatically run our tests while we work on projects
 $ gem install guard guard-minitest
 ```
 
+-> Issue with installing guard - see commit description
+
 After we've got Guard installed, we can start it by running the `guard` command in a terminal. Leave this terminal window open while you work, and Guard will display the results of your tests whenever they are re-run automatically.
 
 _Important_: You need to run `guard` from the "root" directory for the project (the directory which has the `Guardfile`).

--- a/02-intermediate-ruby/testing-with-guard.md
+++ b/02-intermediate-ruby/testing-with-guard.md
@@ -19,7 +19,23 @@ Before we can use Guard to automatically run our tests while we work on projects
 $ gem install guard guard-minitest
 ```
 
--> Issue with installing guard - see commit description
+### If you get an error
+
+If you get the error: 
+
+```bash
+mkmf.rb can't find header files for ruby at /System/Library/Frameworks/Ruby.framework/Versions/2.3/usr/lib/ruby/include/ruby.h
+```
+
+This could be because your mac is on version [10.14](https://github.com/castwide/vscode-solargraph/issues/78).  
+
+You may need to run:
+
+```bash
+$ open /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.14.pkg
+```
+
+### After installing guard
 
 After we've got Guard installed, we can start it by running the `guard` command in a terminal. Leave this terminal window open while you work, and Guard will display the results of your tests whenever they are re-run automatically.
 

--- a/02-intermediate-ruby/testing-with-guard.md
+++ b/02-intermediate-ruby/testing-with-guard.md
@@ -35,6 +35,8 @@ You may need to run:
 $ open /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.14.pkg
 ```
 
+Then try to reinstall guard.
+
 ### After installing guard
 
 After we've got Guard installed, we can start it by running the `guard` command in a terminal. Leave this terminal window open while you work, and Guard will display the results of your tests whenever they are re-run automatically.


### PR DESCRIPTION
I was trying to install guard today and ran into an issue:

mkmf.rb can't find header files for ruby at /System/Library/Frameworks/Ruby.framework/Versions/2.3/usr/lib/ruby/include/ruby.h

I found this post - https://github.com/castwide/vscode-solargraph/issues/78 - which suggested the problem is because my mac is 10.14 

I had to run this command which then allowed me to install guard.

open /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.14.pkg

I wanted to mention this to your team incase you want to include it, though you may not feel it is relevant to Ada students!

David

## Description
A few sentences describing the overall purpose of these textbook changes.

## Questions for the Author
- [ ] Have you updated the weekly learning goals in the pedagogy resource?
- [ ] Have you updated the weekly assessment in Schoology?
- [ ] Have you added links to the source (lucidchart, draw.io) for any diagram?
- [ ] Have you updated the READMEs with links to new or moved resources?

## Todos
Are any of these items still in progress?
- [ ] Section X still needs some more detailed examples
- [ ] Still need to add "Additional Resources"

## Feedback Requested
Please utilize the built-in GitHub Reviewers functionality to assign necessary reviewers. Use this section to further specify portions of the PR that you would like additional or focused feedback on.
